### PR TITLE
get IBM MQ client logs when running distributed

### DIFF
--- a/grizzly_cli/static/Containerfile
+++ b/grizzly_cli/static/Containerfile
@@ -10,7 +10,7 @@ FROM locustio/locust:2.2.1
 
 USER root
 
-RUN mkdir -p /opt/mqm/lib64 && mkdir -p /opt/mqm/lib && mkdir -p /opt/mqm/gskit8/lib64
+RUN mkdir -p /opt/mqm/{lib,lib64,gskit8/lib64,msg/en_US} 
 
 COPY --from=dependencies /root/ibm/inc /opt/mqm/inc
 COPY --from=dependencies /root/ibm/lib/libcurl.so /opt/mqm/lib/
@@ -19,8 +19,11 @@ COPY --from=dependencies /root/ibm/lib/ccsid.tbl /opt/mqm/lib/
 COPY --from=dependencies /root/ibm/lib64/libmqic_r.so /opt/mqm/lib64/
 COPY --from=dependencies /root/ibm/lib64/libmqe_r.so /opt/mqm/lib64/
 COPY --from=dependencies /root/ibm/gskit8/lib64 /opt/mqm/gskit8/lib64/
+COPY --from=dependencies /root/ibm/msg/en_US/amq.cat /opt/mqm/msg/en_US/
 
 ENV LD_LIBRARY_PATH="/opt/mqm/lib64:${LD_LIBRARY_PATH}"
+ENV LC_ALL=C
+ENV LANG=C
 
 RUN apt-get -y update && \
     apt-get install -y \
@@ -38,5 +41,13 @@ RUN apt-get purge -y openssh-client && \
     apt-get autoremove -y && \
     rm -rf /root/.ssh && \
     rm /tmp/requirements.txt
+
+RUN mkdir -p /home/locust/IBM/MQ/data
+
+USER root
+
+RUN mkdir -p /srv/grizzly/features/logs \
+    && ln -sf /srv/grizzly/features/logs /home/locust/IBM/MQ/data/errors \
+    && rm -rf /srv/grizzly/features
 
 USER locust


### PR DESCRIPTION
this is needed to easier troubleshoot connection problems.