### PR TITLE
create a user with uid/gid matching user that executes grizzly-cli

### DIFF
--- a/grizzly_cli/__init__.py
+++ b/grizzly_cli/__init__.py
@@ -115,6 +115,8 @@ def run_command(command: List[str], env: Optional[Dict[str, str]] = None) -> int
                 break
 
             print(output.decode('utf-8').strip())
+
+        process.terminate()
     except KeyboardInterrupt:
         pass
     finally:
@@ -122,5 +124,7 @@ def run_command(command: List[str], env: Optional[Dict[str, str]] = None) -> int
             process.kill()
         except Exception:
             pass
+
+    process.wait()
 
     return process.returncode

--- a/grizzly_cli/cli.py
+++ b/grizzly_cli/cli.py
@@ -220,8 +220,6 @@ def _run_distributed(args: argparse.Namespace, environ: Dict[str, Any], run_argu
     os.environ['GRIZZLY_PROJECT_NAME'] = PROJECT_NAME
     os.environ['GRIZZLY_USER_TAG'] = tag
     os.environ['GRIZZLY_EXPECTED_WORKERS'] = str(args.workers)
-    os.environ['GRIZZLY_UID'] = str(os.getuid())
-    os.environ['GRIZZLY_GID'] = str(os.getgid())
 
     if len(run_arguments['master']) > 0:
         os.environ['GRIZZLY_MASTER_RUN_ARGS'] = ' '.join(run_arguments['master'])
@@ -236,7 +234,10 @@ def _run_distributed(args: argparse.Namespace, environ: Dict[str, Any], run_argu
     images = list_images(args)
 
     if PROJECT_NAME not in images or args.force_build or args.build:
-        build(args)
+        rc = build(args)
+        if rc != 0:
+            print(f'!! failed to build {PROJECT_NAME}, rc={rc}')
+            return rc
 
     # file will be deleted when conContainertext exits
     with NamedTemporaryFile() as fd:

--- a/grizzly_cli/static/Containerfile
+++ b/grizzly_cli/static/Containerfile
@@ -10,7 +10,18 @@ FROM locustio/locust:2.2.1
 
 USER root
 
-RUN mkdir -p /opt/mqm/{lib,lib64,gskit8/lib64,msg/en_US} 
+ARG GRIZZLY_UID
+ARG GRIZZLY_GID
+
+RUN groupadd --gid "${GRIZZLY_GID}" grizzly \
+    && useradd \
+        --uid ${GRIZZLY_UID} \
+        --gid ${GRIZZLY_GID} \
+        --create-home \
+        --shell /bin/bash \
+        grizzly
+
+RUN mkdir -p /opt/mqm/{lib,lib64,gskit8/lib64,msg/en_US}
 
 COPY --from=dependencies /root/ibm/inc /opt/mqm/inc
 COPY --from=dependencies /root/ibm/lib/libcurl.so /opt/mqm/lib/
@@ -42,12 +53,12 @@ RUN apt-get purge -y openssh-client && \
     rm -rf /root/.ssh && \
     rm /tmp/requirements.txt
 
-RUN mkdir -p /home/locust/IBM/MQ/data
+RUN mkdir -p /home/grizzly/IBM/MQ/data
 
 USER root
 
 RUN mkdir -p /srv/grizzly/features/logs \
-    && ln -sf /srv/grizzly/features/logs /home/locust/IBM/MQ/data/errors \
+    && ln -sf /srv/grizzly/features/logs /home/grizzly/IBM/MQ/data/errors \
     && rm -rf /srv/grizzly/features
 
-USER locust
+USER grizzly

--- a/grizzly_cli/static/compose.yaml
+++ b/grizzly_cli/static/compose.yaml
@@ -3,7 +3,6 @@ services:
   master:
     hostname: master
     image: ${GRIZZLY_PROJECT_NAME}:${GRIZZLY_USER_TAG}
-    user: "${GRIZZLY_UID}:${GRIZZLY_GID}"
     ulimits:
       nofile: 10001
     ports:
@@ -25,7 +24,6 @@ services:
 
   worker:
     image: ${GRIZZLY_PROJECT_NAME}:${GRIZZLY_USER_TAG}
-    user: "${GRIZZLY_UID}:${GRIZZLY_GID}"
     ulimits:
       nofile: 10001
     extra_hosts:


### PR DESCRIPTION
specifying `user:` in `compose.yaml` caused some problems with `pymqi`, which needs to create files in `/home/locust`, which would be owened by uid/gid `1000`.