### PR TITLE
remove locust user (uid 1000) when building grizzly container image

### DIFF
--- a/grizzly_cli/static/Containerfile
+++ b/grizzly_cli/static/Containerfile
@@ -13,7 +13,8 @@ USER root
 ARG GRIZZLY_UID
 ARG GRIZZLY_GID
 
-RUN groupadd --gid "${GRIZZLY_GID}" grizzly \
+RUN userdel -rf locust || true \
+    && groupadd --gid "${GRIZZLY_GID}" grizzly \
     && useradd \
         --uid ${GRIZZLY_UID} \
         --gid ${GRIZZLY_GID} \


### PR DESCRIPTION
locust user in locust image has uid 1000.
vscode user in devcontainer image has uid 1000.

when trying to create the grizzly user in the locust image based on the uid/gid of the user that ran `grizzly-cli`, there's a conflict since it tries to create user grizzly with uid 1000, which already exists as user locust.

remove the locust user before trying to create the grizzly user.