### PR TITLE
added arguments for controlling compose health checks

### DIFF
--- a/grizzly_cli/__init__.py
+++ b/grizzly_cli/__init__.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import sys
 
 from typing import Any, Dict, List, Set, Optional
 from json import loads as jsonloads
@@ -76,7 +77,7 @@ def get_default_mtu(args: Arguments) -> Optional[str]:
         return None
 
 
-def run_command(command: List[str], env: Optional[Dict[str, str]] = None) -> int:
+def run_command(command: List[str], env: Optional[Dict[str, str]] = None, silent: bool = False) -> int:
     if env is None:
         env = os.environ.copy()
 
@@ -97,7 +98,8 @@ def run_command(command: List[str], env: Optional[Dict[str, str]] = None) -> int
             if not output:
                 break
 
-            print(output.decode('utf-8').strip())
+            if not silent:
+                sys.stdout.write(output.decode('utf-8'))
 
         process.terminate()
     except KeyboardInterrupt:

--- a/grizzly_cli/static/compose.yaml
+++ b/grizzly_cli/static/compose.yaml
@@ -17,9 +17,9 @@ services:
     env_file: "${GRIZZLY_ENVIRONMENT_FILE}"
     healthcheck:
       test: ["CMD", "lsof", "-i", ":5557", "-sTCP:LISTEN"]
-      interval: 5s
-      timeout: 3s
-      retries: 3
+      interval: ${GRIZZLY_HEALTH_CHECK_INTERVAL}s
+      timeout: ${GRIZZLY_HEALTH_CHECK_TIMEOUT}s
+      retries: ${GRIZZLY_HEALTH_CHECK_RETRIES}
 
   worker:
     image: ${GRIZZLY_PROJECT_NAME}:${GRIZZLY_USER_TAG}

--- a/tests/argparse/bashcompletion/test__init__.py
+++ b/tests/argparse/bashcompletion/test__init__.py
@@ -272,15 +272,15 @@ class TestBashCompleteAction:
         [
             (
                 'grizzly-cli run --yes -T key=value --environment-file test.yaml --testdata-variable key=value dist',
-                '-h --help --workers --id --limit-nofile --force-build --build test.feature test-dir',
+                '-h --help --workers --id --limit-nofile --health-retries --health-timeout --health-interval --force-build --build --validate-config test.feature test-dir',
             ),
             (
                 'grizzly-cli run --yes -T key=value --environment-file test.yaml --testdata-variable key=value dist -',
-                '-h --help --workers --id --limit-nofile --force-build --build',
+                '-h --help --workers --id --limit-nofile --health-retries --health-timeout --health-interval --force-build --build --validate-config',
             ),
             (
                 'grizzly-cli run --yes -T key=value --environment-file test.yaml --testdata-variable key=value dist --',
-                '--help --workers --id --limit-nofile --force-build --build',
+                '--help --workers --id --limit-nofile --health-retries --health-timeout --health-interval --force-build --build --validate-config',
             ),
             (
                 'grizzly-cli run --yes -T key=value --environment-file test.yaml --testdata-variable key=value dist --workers',
@@ -292,11 +292,11 @@ class TestBashCompleteAction:
             ),
             (
                 'grizzly-cli run --yes -T key=value --environment-file test.yaml --testdata-variable key=value dist --workers 8',
-                '-h --help --id --limit-nofile --force-build --build',
+                '-h --help --id --limit-nofile --health-retries --health-timeout --health-interval --force-build --build --validate-config',
             ),
             (
                 'grizzly-cli run --yes -T key=value --environment-file test.yaml --testdata-variable key=value dist --workers 8 --force-build',
-                '-h --help --id --limit-nofile test.feature test-dir',
+                '-h --help --id --limit-nofile --health-retries --health-timeout --health-interval test.feature test-dir',
             ),
             (
                 'grizzly-cli run --yes -T key=value --environment-file test.yaml --testdata-variable key=value dist --workers 8 --force-build test',
@@ -308,7 +308,7 @@ class TestBashCompleteAction:
             ),
             (
                 'grizzly-cli run --yes -T key=value --environment-file test.yaml --testdata-variable key=value dist --workers 8 --force-build test.feature',
-                '-h --help --id --limit-nofile',
+                '-h --help --id --limit-nofile --health-retries --health-timeout --health-interval',
             ),
             (
                 'grizzly-cli run --yes -T key=value --environment-file test.yaml --testdata-variable key=value dist --workers 8 -h --force-build',


### PR DESCRIPTION
needed when there are custom steps causing the master node to delay its start.

always validate compose project file, and fail if it is not valid.

added argument to explicit validate compose project file, and print the
results.