### PR TITLE
getattr retrives value of registry in args, but if it is None

### DIFF
--- a/grizzly_cli/cli.py
+++ b/grizzly_cli/cli.py
@@ -485,7 +485,7 @@ def _run_distributed(args: argparse.Namespace, environ: Dict[str, Any], run_argu
     os.environ['GRIZZLY_HEALTH_CHECK_RETRIES'] = str(args.health_retries)
     os.environ['GRIZZLY_HEALTH_CHECK_INTERVAL'] = str(args.health_interval)
     os.environ['GRIZZLY_HEALTH_CHECK_TIMEOUT'] = str(args.health_timeout)
-    os.environ['GRIZZLY_IMAGE_REGISTRY'] = getattr(args, 'registry', '')
+    os.environ['GRIZZLY_IMAGE_REGISTRY'] = getattr(args, 'registry', None) or ''
 
     if len(run_arguments.get('master', [])) > 0:
         os.environ['GRIZZLY_MASTER_RUN_ARGS'] = ' '.join(run_arguments['master'])


### PR DESCRIPTION
grizzly-cli will not start.
return None if registry does not exists in arguments, and check if
the result is None, then set as an empty string.