### PR TITLE
fix tty size in container

### DIFF
--- a/grizzly_cli/static/compose.yaml
+++ b/grizzly_cli/static/compose.yaml
@@ -12,8 +12,10 @@ services:
       - ${GRIZZLY_MOUNT_CONTEXT}/:/srv/grizzly
     environment:
       - PYTHONPATH=/srv/grizzly
-    entrypoint: /usr/local/bin/behave
-    command: -D master=true -D expected-workers=${GRIZZLY_EXPECTED_WORKERS} /srv/grizzly/${GRIZZLY_RUN_FILE:-features} ${GRIZZLY_MASTER_RUN_ARGS:-} ${GRIZZLY_COMMON_RUN_ARGS:-}
+      - COLUMNS=${COLUMNS}
+      - LINES=${LINES}
+    entrypoint: /bin/bash
+    command: -c "/bin/stty rows ${LINES} cols ${COLUMNS} && /usr/local/bin/behave --no-color -D master=true -D expected-workers=${GRIZZLY_EXPECTED_WORKERS} /srv/grizzly/${GRIZZLY_RUN_FILE:-features} ${GRIZZLY_MASTER_RUN_ARGS:-} ${GRIZZLY_COMMON_RUN_ARGS:-}"
     env_file: "${GRIZZLY_ENVIRONMENT_FILE}"
     healthcheck:
       test: ["CMD", "lsof", "-i", ":5557", "-sTCP:LISTEN"]
@@ -23,6 +25,7 @@ services:
 
   worker:
     image: ${GRIZZLY_IMAGE_REGISTRY}${GRIZZLY_PROJECT_NAME}:${GRIZZLY_USER_TAG}
+    tty: true
     ulimits:
       nofile: 10001
     extra_hosts:
@@ -31,8 +34,10 @@ services:
       - ${GRIZZLY_MOUNT_CONTEXT}/:/srv/grizzly
     environment:
       - PYTHONPATH=/srv/grizzly
-    entrypoint: /usr/local/bin/behave
-    command: -q --no-summary --format null -D worker=true -D master-host=master /srv/grizzly/${GRIZZLY_RUN_FILE:-features} ${GRIZZLY_WORKER_RUN_ARGS:-} ${GRIZZLY_COMMON_RUN_ARGS:-}
+      - COLUMNS=${COLUMNS}
+      - LINES=${LINES}
+    entrypoint: /bin/bash
+    command: -c "/bin/stty rows ${LINES} cols ${COLUMNS} && /usr/local/bin/behave --no-color -q --no-summary --format null -D worker=true -D master-host=master /srv/grizzly/${GRIZZLY_RUN_FILE:-features} ${GRIZZLY_WORKER_RUN_ARGS:-} ${GRIZZLY_COMMON_RUN_ARGS:-}"
     env_file: "${GRIZZLY_ENVIRONMENT_FILE}"
     depends_on:
       master:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
-mypy
-pylint
-pytest
-pytest-cov
-pytest-mock
-pytest-timeout
+mypy==0.910
+pylint==2.12.2
+pytest==6.2.5
+pytest-cov==3.0.0
+pytest-mock==3.6.1
+pytest-timeout==2.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-behave
-roundrobin
-Jinja2
+behave==1.2.6
+roundrobin==0.0.2
+Jinja2==3.0.3


### PR DESCRIPTION
locust uses os.get_terminal_size which in some cases returns 0,0, which
causes locust to use 80 as a terminal width.

this messes up the tables. as a workaround, export COLUMNS and LINES environment variables
from host executing grizzly-cli, set those environment variables in the containers
and set the tty size inside the containerwith stty before starting behave.