### PR TITLE
Feature/get dependencies version

### DIFF
--- a/grizzly_cli/__main__.py
+++ b/grizzly_cli/__main__.py
@@ -32,7 +32,14 @@ def _create_parser() -> ArgumentParser:
     if parser.prog != 'grizzly-cli':
         parser.prog = 'grizzly-cli'
 
-    parser.add_argument('--version', action='store_true', help='print version of command line interface, and exit')
+    parser.add_argument(
+        '--version',
+        nargs='?',
+        default=None,
+        const=True,
+        choices=['all'],
+        help='print version of command line interface, and exit. add argument `all` to get versions of dependencies',
+    )
 
     sub_parser = parser.add_subparsers(dest='category')
 
@@ -64,7 +71,7 @@ def _create_parser() -> ArgumentParser:
         help='if grizzly should be installed with IBM MQ support (external dependencies excluded)',
     )
 
-    if init_parser.prog != 'grizzly-cli init':
+    if init_parser.prog != 'grizzly-cli init':  # pragma: no cover
         init_parser.prog = 'grizzly-cli init'
 
     # grizzly-cli build ...
@@ -87,7 +94,7 @@ def _create_parser() -> ArgumentParser:
         help='push built image to this registry, if the registry has authentication you need to login first',
     )
 
-    if build_parser.prog != 'grizzly-cli build':
+    if build_parser.prog != 'grizzly-cli build':  # pragma: no cover
         build_parser.prog = 'grizzly-cli build'
 
     # grizzly-cli run ...
@@ -125,7 +132,7 @@ def _create_parser() -> ArgumentParser:
         help='configuration file with [environment specific information](/grizzly/usage/variables/environment-configuration/)',
     )
 
-    if run_parser.prog != 'grizzly-cli run':
+    if run_parser.prog != 'grizzly-cli run':  # pragma: no cover
         run_parser.prog = 'grizzly-cli run'
 
     run_sub_parser = run_parser.add_subparsers(dest='mode')
@@ -143,7 +150,7 @@ def _create_parser() -> ArgumentParser:
         **file_kwargs,  # type: ignore
     )
 
-    if run_local_parser.prog != 'grizzly-cli run local':
+    if run_local_parser.prog != 'grizzly-cli run local':  # pragma: no cover
         run_local_parser.prog = 'grizzly-cli run local'
 
     # grizzly-cli run dist ...
@@ -230,7 +237,7 @@ def _create_parser() -> ArgumentParser:
         help='validate and print compose project file',
     )
 
-    if run_dist_parser.prog != 'grizzly-cli run dist':
+    if run_dist_parser.prog != 'grizzly-cli run dist':  # pragma: no cover
         run_dist_parser.prog = 'grizzly-cli run dist'
 
     return parser
@@ -241,10 +248,23 @@ def _parse_arguments() -> argparse.Namespace:
     args = parser.parse_args()
 
     if args.version:
-        grizzly_version, locust_version = get_dependency_versions()
-        print(f'grizzly-cli {__version__}')
-        print(f'grizzly {grizzly_version}')
-        print(f'locust {locust_version}')
+        if __version__ == '0.0.0':
+            version = '(development)'
+        else:
+            version = __version__
+
+        if args.version == 'all':
+            grizzly_version, locust_version = get_dependency_versions()
+        else:
+            grizzly_version, locust_version = None, None
+
+        print(f'grizzly-cli {version}')
+        if grizzly_version is not None:
+            print(f'└── grizzly {grizzly_version}')
+
+        if locust_version is not None:
+            print(f'    └── locust {locust_version}')
+
         raise SystemExit(0)
 
     if args.category is None:

--- a/grizzly_cli/__main__.py
+++ b/grizzly_cli/__main__.py
@@ -1,4 +1,3 @@
-import sys
 import argparse
 import os
 
@@ -6,7 +5,7 @@ from shutil import which
 
 from .argparse import ArgumentParser
 from .argparse.bashcompletion import BashCompletionTypes
-from .utils import ask_yes_no, get_distributed_system
+from .utils import ask_yes_no, get_distributed_system, get_dependency_versions
 from .run import run
 from .build import build
 from .init import init
@@ -242,7 +241,10 @@ def _parse_arguments() -> argparse.Namespace:
     args = parser.parse_args()
 
     if args.version:
-        print(__version__)
+        grizzly_version, locust_version = get_dependency_versions()
+        print(f'grizzly-cli {__version__}')
+        print(f'grizzly {grizzly_version}')
+        print(f'locust {locust_version}')
         raise SystemExit(0)
 
     if args.category is None:
@@ -302,7 +304,3 @@ def main() -> int:
 
         print('\n!! aborted grizzly-cli')
         return 1
-
-
-if __name__ == '__main__':
-    sys.exit(main())

--- a/grizzly_cli/build.py
+++ b/grizzly_cli/build.py
@@ -4,7 +4,7 @@ from typing import List, cast
 from argparse import Namespace as Arguments
 from getpass import getuser
 
-from .utils import requirements, run_command
+from .utils import get_dependency_versions, requirements, run_command
 from . import EXECUTION_CONTEXT, PROJECT_NAME, STATIC_CONTEXT
 
 
@@ -23,12 +23,18 @@ def getgid() -> int:
 
 
 def _create_build_command(args: Arguments, containerfile: str, tag: str, context: str) -> List[str]:
+    _, locust_version = get_dependency_versions()
+
+    if locust_version == '(unknown)':
+        locust_version = 'latest'
+
     return [
         f'{args.container_system}',
         'image',
         'build',
         '--ssh',
         'default',
+        '--build-arg', f'LOCUST_VERSION={locust_version}',
         '--build-arg', f'GRIZZLY_UID={getuid()}',
         '--build-arg', f'GRIZZLY_GID={getgid()}',
         '-f', containerfile,

--- a/grizzly_cli/static/Containerfile
+++ b/grizzly_cli/static/Containerfile
@@ -1,3 +1,5 @@
+ARG LOCUST_VERSION
+
 FROM alpine:latest as dependencies
 
 USER root
@@ -6,7 +8,7 @@ RUN mkdir /root/ibm && cd /root/ibm && \
     wget https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/redist/9.2.2.0-IBM-MQC-Redist-LinuxX64.tar.gz -O - | tar xzf -
 
 
-FROM locustio/locust:2.7.3
+FROM locustio/locust:${LOCUST_VERSION}
 
 USER root
 

--- a/grizzly_cli/utils.py
+++ b/grizzly_cli/utils.py
@@ -13,6 +13,7 @@ from json import loads as jsonloads
 from functools import wraps
 from packaging import version as versioning
 from tempfile import mkdtemp
+from hashlib import sha1
 
 import requests
 
@@ -63,125 +64,174 @@ def run_command(command: List[str], env: Optional[Dict[str, str]] = None, silent
 
 def get_dependency_versions() -> Tuple[str, str]:
     grizzly_requirement: Optional[str] = None
-    locust_version: str
-    grizzly_version: str
+    locust_version: Optional[str] = None
+    grizzly_version: Optional[str] = None
 
-    with open(path.join(grizzly_cli.EXECUTION_CONTEXT, 'requirements.txt'), encoding='utf-8') as fd:
+    project_requirements = path.join(grizzly_cli.EXECUTION_CONTEXT, 'requirements.txt')
+
+    with open(project_requirements, encoding='utf-8') as fd:
         for line in fd.readlines():
             if any([pkg in line for pkg in ['grizzly-loadtester', 'grizzly.git'] if not re.match(r'^([\s]+)?#', line)]):
                 grizzly_requirement = line.strip()
                 break
 
-    assert grizzly_requirement is not None
-
-    print(f'grizzly_requirements={grizzly_requirement}')
+    if grizzly_requirement is None:
+        print(f'!! unable to find grizzly dependency in {project_requirements}', file=sys.stderr)
+        return '(unknown)', '(unknown)'
 
     # check if it's a repo or not
     if grizzly_requirement.startswith('git+'):
-        # git+https://git@github.com/mgor/grizzly.git@feature/dependency_update_round_2#egg=grizzly-loadtester
-        # Running command git clone --filter=blob:none -q 'https://****@github.com/mgor/grizzly.git' /tmp/pip-download-xv37p0tn/grizzly-loadtester_1ae112f4280348fdaa907fee67488f71
-        # Running command git checkout -b feature/dependency_update_round_2 --track origin/feature/dependency_update_round_2
-        url, _ = grizzly_requirement.rsplit('#', 1)
+        suffix = sha1(grizzly_requirement.encode('utf-8')).hexdigest()
+        url, egg_part = grizzly_requirement.rsplit('#', 1)
         url, branch = url.rsplit('@', 1)
         url = url[4:]  # remove git+
+        _, egg = egg_part.split('=', 1)
 
-        print(f'url={url}')
-        print(f'branch={branch}')
+        # extras_requirement normalization
+        egg = egg.replace('[', '__').replace(']', '__')
 
-        tmp_workspace = mkdtemp()
-        print(tmp_workspace)
+        tmp_workspace = mkdtemp(prefix='grizzly-cli-')
+        repo_destination = path.join(tmp_workspace, f'{egg}_{suffix}')
+
         try:
-            rc = subprocess.check_call([
-                'git',
-                'clone',
-                '--filter=blob:none',
-                '-q',
-                url,
-                tmp_workspace,
-            ], shell=False)
+            rc: int = 0
 
-            assert rc == 0
+            rc += subprocess.check_call(
+                [
+                    'git', 'clone', '--filter=blob:none', '-q',
+                    url,
+                    repo_destination
+                ],
+                shell=False,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
 
-            rc = subprocess.check_call([
-                'git',
-                'checkout',
-                '-b', branch,
-                '--track', f'origin/{branch}',
-            ], shell=True, cwd=tmp_workspace)
+            rc += subprocess.check_call(
+                [
+                    'git', 'checkout',
+                    '-b', branch,
+                    '--track', f'origin/{branch}',
+                ],
+                cwd=repo_destination,
+                shell=False,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
 
-            assert rc == 0
-        except:
-            input('waiting to continue...')
+            if rc != 0:
+                print(f'!! unable to get git repo {url} and branch {branch}', file=sys.stderr)
+                raise RuntimeError()  # abort
+
+            with open(path.join(repo_destination, 'grizzly', '__init__.py'), encoding='utf-8') as fd:
+                version_raw = [line.strip() for line in fd.readlines() if line.strip().startswith('__version__ =')]
+
+            if len(version_raw) != 1:
+                print(f'!! unable to find "__version__" declaration in grizzly/__init__.py from {url}', file=sys.stderr)
+                raise RuntimeError()  # abort
+
+            _, grizzly_version, _ = version_raw[-1].split("'")
+
+            if grizzly_version == '0.0.0':
+                grizzly_version = '(development)'
+
+            with open(path.join(repo_destination, 'requirements.txt'), encoding='utf-8') as fd:
+                version_raw = [line.strip() for line in fd.readlines() if line.strip().startswith('locust')]
+
+            if len(version_raw) != 1:
+                print(f'!! unable to find "locust" dependency in requirements.txt from {url}', file=sys.stderr)
+                raise RuntimeError()  # abort
+
+            match = re.match(r'^locust.{2}([^\s]+)\s+', version_raw[-1])
+
+            if not match:
+                print(f'!! unable to find locust version in "{version_raw[-1].strip()}" specified in requirements.txt from {url}', file=sys.stderr)
+            else:
+                locust_version = match.group(1)
+        except RuntimeError:
+            pass
         finally:
             rmtree(tmp_workspace)
-        return '', ''
     else:
         response = requests.get(
             'https://pypi.org/pypi/grizzly-loadtester/json'
         )
 
         if response.status_code != 200:
-            response.raise_for_status()
-
-        pypi = jsonloads(response.text)
-
-        # get grizzly version used in rquirements.txt
-        if re.match(r'^grizzly-loadtester(\[[^\]]\])?$', grizzly_requirement):  # latest
-            grizzly_version = pypi.get('info', {}).get('version', None)
+            print(f'!! unable to get grizzly package information from {response.url} ({response.status_code})', file=sys.stderr)
         else:
-            available_versions = [versioning.parse(available_version) for available_version in pypi.get('releases', {}).keys()]
-            conditions: List[Callable[[versioning.Version], bool]] = []
+            pypi = jsonloads(response.text)
 
-            for condition in grizzly_requirement.replace('grizzly-loadtester', '').split(',', 1):
-                condition_version = versioning.parse(re.sub(r'[^0-9\.]', '', condition))
+            # get grizzly version used in requirements.txt
+            if re.match(r'^grizzly-loadtester(\[[^\]]\])?$', grizzly_requirement):  # latest
+                grizzly_version = pypi.get('info', {}).get('version', None)
+            else:
+                available_versions = [versioning.parse(available_version) for available_version in pypi.get('releases', {}).keys()]
+                conditions: List[Callable[[versioning.Version], bool]] = []
 
-                if not isinstance(condition_version, versioning.Version):
-                    raise ValueError(f'{str(condition_version)} is a {condition_version.__class__.__name__}, expected Version')
+                for condition in grizzly_requirement.replace('grizzly-loadtester', '').split(',', 1):
+                    condition_version = versioning.parse(re.sub(r'[^0-9\.]', '', condition))
 
-                if '>' in condition:
-                    compare = condition_version.__le__ if '=' in condition else condition_version.__lt__
-                elif '<' in condition:
-                    compare = condition_version.__ge__ if '=' in condition else condition_version.__gt__
+                    if not isinstance(condition_version, versioning.Version):
+                        print(f'!! {str(condition_version)} is a {condition_version.__class__.__name__}, expected Version', file=sys.stderr)
+                        break
+
+                    if '>' in condition:
+                        compare = condition_version.__le__ if '=' in condition else condition_version.__lt__
+                    elif '<' in condition:
+                        compare = condition_version.__ge__ if '=' in condition else condition_version.__gt__
+                    else:
+                        compare = condition_version.__eq__
+
+                    conditions.append(compare)
+
+                matched_version = None
+
+                for available_version in available_versions:
+                    if not isinstance(available_version, versioning.Version):
+                        print(f'{str(condition_version)} is a {condition_version.__class__.__name__}, expected Version', file=sys.stderr)
+                        break
+
+                    if all([compare(available_version) for compare in conditions]):
+                        matched_version = available_version
+
+                if matched_version is None:
+                    print(f'!! could not resolve {grizzly_requirement} to one specific version available at pypi', file=sys.stderr)
                 else:
-                    compare = condition_version.__eq__
+                    grizzly_version = str(matched_version)
 
-                conditions.append(compare)
+            # get version from pypi, to be able to get locust version
+            response = requests.get(
+                f'https://pypi.org/pypi/grizzly-loadtester/{grizzly_version}/json'
+            )
 
-            matched_version = None
+            if response.status_code != 200:
+                print(f'!! unable to get grizzly {grizzly_version} package information from {response.url} ({response.status_code})', file=sys.stderr)
+            else:
+                release_info = jsonloads(response.text)
 
-            for available_version in available_versions:
-                if not isinstance(available_version, versioning.Version):
-                    raise ValueError(f'{str(condition_version)} is a {condition_version.__class__.__name__}, expected Version')
+                for requires_dist in release_info.get('info', {}).get('requires_dist', []):
+                    if not requires_dist.startswith('locust'):
+                        continue
 
-                if all([compare(available_version) for compare in conditions]):
-                    matched_version = available_version
+                    match = re.match(r'^locust \([^0-9]{2}(.+)\)$', requires_dist.strip())
 
-            assert matched_version is not None
+                    if not match:
+                        print(f'!! unable to find locust version in "{requires_dist.strip()}" specified in pypi for grizzly-loadtester {grizzly_version}', file=sys.stderr)
+                        locust_version = '(unknown)'
+                        break
 
-            grizzly_version = str(matched_version)
+                    locust_version = match.group(1)
+                    break
 
-        # get version from pypi, to be able to get locust version
-        response = requests.get(
-            f'https://pypi.org/pypi/grizzly-loadtester/{grizzly_version}/json'
-        )
+                if locust_version is None:
+                    print(f'!! could not find "locust" in requires_dist information for grizzly-loadtester {grizzly_version}', file=sys.stderr)
 
-        if response.status_code != 200:
-            response.raise_for_status()
+    if grizzly_version is None:
+        grizzly_version = '(unknown)'
 
-        release_info = jsonloads(response.text)
-
-        for required_dist in release_info['info']['requires_dist']:
-            if not required_dist.startswith('locust'):
-                continue
-
-            match = re.match(r'^locust \([^0-9]{2}(.+)\)$', required_dist.strip())
-
-            assert match
-
-            locust_version = match.group(1)
-            break
-
-        assert locust_version is not None
+    if locust_version is None:
+        locust_version = '(unknown)'
 
     return grizzly_version, locust_version
 
@@ -272,7 +322,7 @@ def get_distributed_system() -> Optional[str]:
     return container_system
 
 
-def get_input(text: str) -> str:
+def get_input(text: str) -> str:  # pragma: no cover
     return input(text).strip()
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ pytest-cov>=3.0.0
 pytest-mock==3.6.1
 pytest-timeout>=2.1.0
 flake8>=4.0.0
+types-requests==2.27.13

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,4 @@ pytest-mock==3.6.1
 pytest-timeout>=2.1.0
 flake8>=4.0.0
 types-requests==2.27.13
+requests-mock==1.9.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,3 @@ behave>=1.2.6
 roundrobin==0.0.2
 Jinja2==3.0.3
 requests==2.27.1
-#grizzly-loadtester>=1.4.0,<1.5.0
-git+https://git@github.com/mgor/grizzly.git@feature/dependency_update_round_2#egg=grizzly-loadtester

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 behave>=1.2.6
 roundrobin==0.0.2
 Jinja2==3.0.3
+requests==2.27.1
+#grizzly-loadtester>=1.4.0,<1.5.0
+git+https://git@github.com/mgor/grizzly.git@feature/dependency_update_round_2#egg=grizzly-loadtester

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -29,8 +29,12 @@ def test_getuid_getgid_nt(mocker: MockerFixture) -> None:
 
 
 def test__create_build_command(mocker: MockerFixture) -> None:
-    mocker.patch('grizzly_cli.build.getuid', side_effect=[1337])
-    mocker.patch('grizzly_cli.build.getgid', side_effect=[2147483647])
+    mocker.patch('grizzly_cli.build.getuid', side_effect=[1337] * 2)
+    mocker.patch('grizzly_cli.build.getgid', side_effect=[2147483647] * 2)
+    mocker.patch('grizzly_cli.build.get_dependency_versions', side_effect=[
+        ('(unknown)', '(unknown)',),
+        ('(unknown)', '1.3.37',),
+    ])
     args = Namespace(container_system='test')
 
     assert _create_build_command(args, 'Containerfile.test', 'grizzly-cli:test', '/home/grizzly-cli/') == [
@@ -39,6 +43,21 @@ def test__create_build_command(mocker: MockerFixture) -> None:
         'build',
         '--ssh',
         'default',
+        '--build-arg', 'LOCUST_VERSION=latest',
+        '--build-arg', 'GRIZZLY_UID=1337',
+        '--build-arg', 'GRIZZLY_GID=2147483647',
+        '-f', 'Containerfile.test',
+        '-t', 'grizzly-cli:test',
+        '/home/grizzly-cli/',
+    ]
+
+    assert _create_build_command(args, 'Containerfile.test', 'grizzly-cli:test', '/home/grizzly-cli/') == [
+        'test',
+        'image',
+        'build',
+        '--ssh',
+        'default',
+        '--build-arg', 'LOCUST_VERSION=1.3.37',
         '--build-arg', 'GRIZZLY_UID=1337',
         '--build-arg', 'GRIZZLY_GID=2147483647',
         '-f', 'Containerfile.test',
@@ -59,6 +78,7 @@ def test_build(capsys: CaptureFixture, mocker: MockerFixture, tmp_path_factory: 
         mocker.patch('grizzly_cli.build.getuser', side_effect=['test-user'] * 5)
         mocker.patch('grizzly_cli.build.getuid', side_effect=[1337] * 5)
         mocker.patch('grizzly_cli.build.getgid', side_effect=[2147483647] * 5)
+        mocker.patch('grizzly_cli.build.get_dependency_versions', side_effect=[('1.2.3', '3.2.1',)] * 5)
         run_command = mocker.patch('grizzly_cli.build.run_command', side_effect=[254, 133, 0, 1, 0, 0, 2, 0, 0, 0])
         setattr(getattr(build, '__wrapped__'), '__value__', str(test_context))
 
@@ -83,6 +103,7 @@ def test_build(capsys: CaptureFixture, mocker: MockerFixture, tmp_path_factory: 
             'build',
             '--ssh',
             'default',
+            '--build-arg', 'LOCUST_VERSION=3.2.1',
             '--build-arg', 'GRIZZLY_UID=1337',
             '--build-arg', 'GRIZZLY_GID=2147483647',
             '-f', f'{static_context}/Containerfile',
@@ -106,6 +127,7 @@ def test_build(capsys: CaptureFixture, mocker: MockerFixture, tmp_path_factory: 
             'build',
             '--ssh',
             'default',
+            '--build-arg', 'LOCUST_VERSION=3.2.1',
             '--build-arg', 'GRIZZLY_UID=1337',
             '--build-arg', 'GRIZZLY_GID=2147483647',
             '-f', f'{static_context}/Containerfile',


### PR DESCRIPTION
decouple locust version used in `grizzly` with version used in `static/Containerfile`.

instead of hard coded and the need to update both projects, find out which grizzly version the project where `grizzly-cli` is executed is based on, and then look which locust version that grizzly version is built with.