### PR TITLE
possible to override  IBM MQ lib redist package download host

### DIFF
--- a/grizzly_cli/build.py
+++ b/grizzly_cli/build.py
@@ -57,6 +57,12 @@ def _create_build_command(args: Arguments, containerfile: str, tag: str, context
     else:
         grizzly_extra = 'base'
 
+    extra_args: List[str] = []
+
+    ibm_mq_lib_host = os.environ.get('IBM_MQ_LIB_HOST', None)
+    if ibm_mq_lib_host is not None:
+        extra_args += ['--build-arg', f'IBM_MQ_LIB_HOST={ibm_mq_lib_host}']
+
     return [
         f'{args.container_system}',
         'image',
@@ -66,6 +72,7 @@ def _create_build_command(args: Arguments, containerfile: str, tag: str, context
         '--build-arg', f'GRIZZLY_EXTRA={grizzly_extra}',
         '--build-arg', f'GRIZZLY_UID={getuid()}',
         '--build-arg', f'GRIZZLY_GID={getgid()}',
+        *extra_args,
         '-f', containerfile,
         '-t', tag,
         context

--- a/grizzly_cli/static/Containerfile
+++ b/grizzly_cli/static/Containerfile
@@ -9,10 +9,14 @@ RUN apt-get update
 # <!-- mq
 FROM base as mq
 
+ARG IBM_MQ_LIB_HOST=https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/redist
+
 RUN apt-get install -y --no-install-recommends wget
 
+ENV IBM_MQ_LIB_HOST=${IBM_MQ_LIB_HOST}
+
 RUN mkdir /tmp/mqm && cd /tmp/mqm && \
-    wget -q --show-progress https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/redist/9.2.2.0-IBM-MQC-Redist-LinuxX64.tar.gz -O - | tar xzf -
+    wget -q --show-progress ${IBM_MQ_LIB_HOST}/9.2.2.0-IBM-MQC-Redist-LinuxX64.tar.gz -O - | tar xzf -
 
 RUN mkdir -p /opt/mqm/inc \
     && mkdir -p /opt/mqm/lib \

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -81,22 +81,28 @@ def test__create_build_command(mocker: MockerFixture) -> None:
         '/home/grizzly-cli/',
     ]
 
-    environ['IBM_MQ_LIB_HOST'] = 'https://localhost:8003'
+    try:
+        environ['IBM_MQ_LIB_HOST'] = 'https://localhost:8003'
 
-    assert _create_build_command(args, 'Containerfile.test', 'grizzly-cli:test', '/home/grizzly-cli/') == [
-        'test',
-        'image',
-        'build',
-        '--ssh',
-        'default',
-        '--build-arg', 'GRIZZLY_EXTRA=mq',
-        '--build-arg', 'GRIZZLY_UID=1337',
-        '--build-arg', 'GRIZZLY_GID=2147483647',
-        '--build-arg', 'IBM_MQ_LIB_HOST=https://localhost:8003',
-        '-f', 'Containerfile.test',
-        '-t', 'grizzly-cli:test',
-        '/home/grizzly-cli/',
-    ]
+        assert _create_build_command(args, 'Containerfile.test', 'grizzly-cli:test', '/home/grizzly-cli/') == [
+            'test',
+            'image',
+            'build',
+            '--ssh',
+            'default',
+            '--build-arg', 'GRIZZLY_EXTRA=mq',
+            '--build-arg', 'GRIZZLY_UID=1337',
+            '--build-arg', 'GRIZZLY_GID=2147483647',
+            '--build-arg', 'IBM_MQ_LIB_HOST=https://localhost:8003',
+            '-f', 'Containerfile.test',
+            '-t', 'grizzly-cli:test',
+            '/home/grizzly-cli/',
+        ]
+    finally:
+        try:
+            del environ['IBM_MQ_LIB_HOST']
+        except KeyError:
+            pass
 
 
 def test_build(capsys: CaptureFixture, mocker: MockerFixture, tmp_path_factory: TempPathFactory) -> None:

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -81,6 +81,23 @@ def test__create_build_command(mocker: MockerFixture) -> None:
         '/home/grizzly-cli/',
     ]
 
+    environ['IBM_MQ_LIB_HOST'] = 'https://localhost:8003'
+
+    assert _create_build_command(args, 'Containerfile.test', 'grizzly-cli:test', '/home/grizzly-cli/') == [
+        'test',
+        'image',
+        'build',
+        '--ssh',
+        'default',
+        '--build-arg', 'GRIZZLY_EXTRA=mq',
+        '--build-arg', 'GRIZZLY_UID=1337',
+        '--build-arg', 'GRIZZLY_GID=2147483647',
+        '--build-arg', 'IBM_MQ_LIB_HOST=https://localhost:8003',
+        '-f', 'Containerfile.test',
+        '-t', 'grizzly-cli:test',
+        '/home/grizzly-cli/',
+    ]
+
 
 def test_build(capsys: CaptureFixture, mocker: MockerFixture, tmp_path_factory: TempPathFactory) -> None:
     test_context = tmp_path_factory.mktemp('test_context')


### PR DESCRIPTION
by setting environment variable IBM_MQ_LIB_HOST before running `grizzly-cli build...`