### PR TITLE
no smoothed timeline in test summary

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,6 @@ python_requires = >=3.6
 packages = find:
 install_requires =
     behave >=1.2.6,<2.0.0
-    roundrobin >=0.0.2,<1.0.0
     Jinja2 >=3.0.3,<4.0.0
     requests >=2.27.1,<3.0.0
     packaging >=21.3,<22.0

--- a/tests/test___init__.py
+++ b/tests/test___init__.py
@@ -22,11 +22,11 @@ def test___import__(tmp_path_factory: TempPathFactory, mocker: MockerFixture) ->
 
         import grizzly_cli
         reload(grizzly_cli)
-        mocker.patch.object(grizzly_cli, '__version__', '0.0.0')
+        mocker.patch.object(grizzly_cli, '__version__', '1.2.3')
 
         static_context = path.join(path.dirname(getfile(grizzly_cli)), 'static')
 
-        assert grizzly_cli.__version__ == '0.0.0'
+        assert grizzly_cli.__version__ == '1.2.3'
         assert grizzly_cli.EXECUTION_CONTEXT == test_context_root
         assert grizzly_cli.MOUNT_CONTEXT == '/var/tmp'
         assert grizzly_cli.STATIC_CONTEXT == static_context


### PR DESCRIPTION
in biometria-se/grizzly#84 the behavior is changed to used fixed_count
for a user (based on user weight and total number of users).

this means that the timeline is not applicable anymore, so instead
calculate how many users a scenario will get from the "pool", and show
it in the summary.