### PR TITLE
restructuring commands

### DIFF
--- a/grizzly_cli/distributed/__init__.py
+++ b/grizzly_cli/distributed/__init__.py
@@ -1,0 +1,271 @@
+import os
+import sys
+import argparse
+
+from typing import List, Dict, Any, cast
+from tempfile import NamedTemporaryFile
+from getpass import getuser
+from shutil import get_terminal_size
+from argparse import Namespace as Arguments
+
+from .. import EXECUTION_CONTEXT, STATIC_CONTEXT, MOUNT_CONTEXT, PROJECT_NAME, register_parser
+from ..utils import (
+    is_docker_compose_v2,
+    run_command,
+    get_default_mtu,
+    list_images,
+)
+from .build import build as do_build, create_parser as build_create_parser
+from ..run import create_parser as run_create_parser, run
+from ..argparse import ArgumentSubParser
+
+
+@register_parser(order=3)
+def create_parser(sub_parser: ArgumentSubParser) -> None:
+    dist_parser = sub_parser.add_parser('dist', description='commands for running grizzly i distributed mode.')
+
+    dist_parser.add_argument(
+        '--workers',
+        type=int,
+        required=False,
+        default=1,
+        help='how many instances of the `workers` container that should be created',
+    )
+    dist_parser.add_argument(
+        '--container-system',
+        type=str,
+        choices=['podman', 'docker', None],
+        required=False,
+        default=None,
+        help=argparse.SUPPRESS,
+    )
+    dist_parser.add_argument(
+        '--id',
+        type=str,
+        required=False,
+        default=None,
+        help='unique identifier suffixed to compose project, should be used when the same user needs to run more than one instance of `grizzly-cli`',
+    )
+    dist_parser.add_argument(
+        '--limit-nofile',
+        type=int,
+        required=False,
+        default=10001,
+        help='set system limit "number of open files"',
+    )
+    dist_parser.add_argument(
+        '--health-retries',
+        type=int,
+        required=False,
+        default=3,
+        help='set number of retries for health check of master container',
+    )
+    dist_parser.add_argument(
+        '--health-timeout',
+        type=int,
+        required=False,
+        default=3,
+        help='set timeout in seconds for health check of master container',
+    )
+    dist_parser.add_argument(
+        '--health-interval',
+        type=int,
+        required=False,
+        default=5,
+        help='set interval in seconds between health checks of master container',
+    )
+    dist_parser.add_argument(
+        '--registry',
+        type=str,
+        default=None,
+        required=False,
+        help='push built image to this registry, if the registry has authentication you need to login first',
+    )
+    dist_parser.add_argument(
+        '--tty',
+        action='store_true',
+        default=False,
+        required=False,
+        help='start containers with a TTY enabled',
+    )
+
+    group_build = dist_parser.add_mutually_exclusive_group()
+    group_build.add_argument(
+        '--force-build',
+        action='store_true',
+        required=False,
+        help='force rebuild the grizzly projects container image (no cache)',
+    )
+    group_build.add_argument(
+        '--build',
+        action='store_true',
+        required=False,
+        help='rebuild the grizzly projects container images (with cache)',
+    )
+    group_build.add_argument(
+        '--validate-config',
+        action='store_true',
+        required=False,
+        help='validate and print compose project file',
+    )
+
+    if dist_parser.prog != 'grizzly-cli dist':  # pragma: no cover
+        dist_parser.prog = 'grizzly-cli dist'
+
+    sub_parser = dist_parser.add_subparsers(dest='subcommand')
+
+    build_create_parser(sub_parser)
+    run_create_parser(sub_parser, parent='dist')
+
+
+def distributed(args: Arguments) -> int:
+    if args.subcommand == 'run':
+        return run(args, distributed_run)
+    elif args.subcommand == 'build':
+        return do_build(args)
+    else:
+        raise ValueError(f'unknown subcommand {args.subcommand}')
+
+
+def distributed_run(args: Arguments, environ: Dict[str, Any], run_arguments: Dict[str, List[str]]) -> int:
+    suffix = '' if args.id is None else f'-{args.id}'
+    tag = getuser()
+
+    # default locust project
+    compose_args: List[str] = [
+        '-p', f'{PROJECT_NAME}{suffix}-{tag}',
+        '-f', f'{STATIC_CONTEXT}/compose.yaml',
+    ]
+
+    if args.file is not None:
+        os.environ['GRIZZLY_RUN_FILE'] = args.file
+
+    mtu = get_default_mtu(args)
+
+    if mtu is None and os.environ.get('GRIZZLY_MTU', None) is None:
+        print('!! unable to determine MTU, try manually setting GRIZZLY_MTU environment variable if anything other than 1500 is needed')
+        mtu = '1500'
+
+    columns, lines = get_terminal_size()
+
+    # set environment variables needed by compose files, when *-compose executes
+    os.environ['GRIZZLY_MTU'] = cast(str, mtu)
+    os.environ['GRIZZLY_EXECUTION_CONTEXT'] = EXECUTION_CONTEXT
+    os.environ['GRIZZLY_STATIC_CONTEXT'] = STATIC_CONTEXT
+    os.environ['GRIZZLY_MOUNT_CONTEXT'] = MOUNT_CONTEXT
+    os.environ['GRIZZLY_PROJECT_NAME'] = PROJECT_NAME
+    os.environ['GRIZZLY_USER_TAG'] = tag
+    os.environ['GRIZZLY_EXPECTED_WORKERS'] = str(args.workers)
+    os.environ['GRIZZLY_LIMIT_NOFILE'] = str(args.limit_nofile)
+    os.environ['GRIZZLY_HEALTH_CHECK_RETRIES'] = str(args.health_retries)
+    os.environ['GRIZZLY_HEALTH_CHECK_INTERVAL'] = str(args.health_interval)
+    os.environ['GRIZZLY_HEALTH_CHECK_TIMEOUT'] = str(args.health_timeout)
+    os.environ['GRIZZLY_IMAGE_REGISTRY'] = getattr(args, 'registry', None) or ''
+    os.environ['GRIZZLY_CONTAINER_TTY'] = 'true' if args.tty else 'false'
+    os.environ['COLUMNS'] = str(columns)
+    os.environ['LINES'] = str(lines)
+
+    if len(run_arguments.get('master', [])) > 0:
+        os.environ['GRIZZLY_MASTER_RUN_ARGS'] = ' '.join(run_arguments['master'])
+
+    if len(run_arguments.get('worker', [])) > 0:
+        os.environ['GRIZZLY_WORKER_RUN_ARGS'] = ' '.join(run_arguments['worker'])
+
+    if len(run_arguments.get('common', [])) > 0:
+        os.environ['GRIZZLY_COMMON_RUN_ARGS'] = ' '.join(run_arguments['common'])
+
+    # check if we need to build image
+    images = list_images(args)
+
+    with NamedTemporaryFile() as fd:
+        # file will be deleted when conContainertext exits
+        if len(environ) > 0:
+            for key, value in environ.items():
+                if key == 'GRIZZLY_CONFIGURATION_FILE':
+                    value = value.replace(EXECUTION_CONTEXT, MOUNT_CONTEXT).replace(MOUNT_CONTEXT, '/srv/grizzly')
+
+                fd.write(f'{key}={value}\n'.encode('utf-8'))
+
+        fd.write(f'COLUMNS={columns}\n'.encode('utf-8'))
+        fd.write(f'LINES={lines}\n'.encode('utf-8'))
+        fd.write(f'GRIZZLY_CONTAINER_TTY={os.environ["GRIZZLY_CONTAINER_TTY"]}\n'.encode('utf-8'))
+
+        fd.flush()
+
+        os.environ['GRIZZLY_ENVIRONMENT_FILE'] = fd.name
+
+        validate_config = getattr(args, 'validate_config', False)
+
+        compose_command = [
+            f'{args.container_system}-compose',
+            *compose_args,
+            'config',
+        ]
+
+        rc = run_command(compose_command, silent=not validate_config)
+
+        if validate_config or rc != 0:
+            if rc != 0 and not validate_config:
+                print('!! something in the compose project is not valid, check with:')
+                print(f'grizzly-cli {" ".join(sys.argv[1:])} --validate-config')
+
+            return rc
+
+        if images.get(PROJECT_NAME, {}).get(tag, None) is None or args.force_build or args.build:
+            rc = do_build(args)
+            if rc != 0:
+                print(f'!! failed to build {PROJECT_NAME}, rc={rc}')
+                return rc
+
+        compose_scale_argument = ['--scale', f'worker={args.workers}']
+
+        # bring up containers
+        compose_command = [
+            f'{args.container_system}-compose',
+            *compose_args,
+            'up',
+            *compose_scale_argument,
+            '--remove-orphans',
+        ]
+
+        rc = run_command(compose_command, verbose=args.verbose)
+
+        # stop containers
+        compose_command = [
+            f'{args.container_system}-compose',
+            *compose_args,
+            'stop',
+        ]
+
+        run_command(compose_command)
+
+        if rc != 0:
+            print('\n!! something went wrong, check container logs with:')
+            template = '{container_system} container logs '
+            if is_docker_compose_v2():
+                template += '{project}{suffix}-{tag}-{node}-{index}'
+                start_index = 2
+            else:
+                template += '{project}{suffix}-{tag}_{node}_{index}'
+                start_index = 1
+
+            print(template.format(
+                container_system=args.container_system,
+                project=PROJECT_NAME,
+                suffix=suffix,
+                tag=tag,
+                node='master',
+                index=1
+            ))
+
+            for worker in range(start_index, args.workers + start_index):
+                print(template.format(
+                    container_system=args.container_system,
+                    project=PROJECT_NAME,
+                    suffix=suffix,
+                    tag=tag,
+                    node='worker',
+                    index=worker
+                ))
+
+        return rc

--- a/grizzly_cli/distributed/build.py
+++ b/grizzly_cli/distributed/build.py
@@ -5,18 +5,16 @@ from argparse import Namespace as Arguments
 from getpass import getuser
 from socket import gethostbyname, gaierror
 
-from .utils import get_dependency_versions, requirements, run_command
-from .argparse import ArgumentSubParser
-from . import EXECUTION_CONTEXT, PROJECT_NAME, STATIC_CONTEXT, register_parser
+from ..utils import get_dependency_versions, requirements, run_command
+from ..argparse import ArgumentSubParser
+from .. import EXECUTION_CONTEXT, PROJECT_NAME, STATIC_CONTEXT
 
 
-@register_parser(order=2)
 def create_parser(sub_parser: ArgumentSubParser) -> None:
-    # grizzly-cli build ...
+    # grizzly-cli dist build ...
     build_parser = sub_parser.add_parser('build', description=(
-        'build grizzly compose project container image. this command is only applicable if grizzly '
-        'should run distributed and is used to pre-build the container images. if worker nodes runs '
-        'on different physical computers, it is mandatory to build the images before hand and push to a registry.'
+        'build grizzly compose project container image before running test. if worker nodes runs on different physical '
+        'computers, it is mandatory to build the images before hand and push to a registry.'
         '\n\n'
         'if image includes IBM MQ native dependencies, the build time increases due to download times. it is possible '
         'to self-host the archive and override the download host with environment variable `IBM_MQ_LIB_HOST`.'
@@ -35,8 +33,8 @@ def create_parser(sub_parser: ArgumentSubParser) -> None:
         help='push built image to this registry, if the registry has authentication you need to login first',
     )
 
-    if build_parser.prog != 'grizzly-cli build':  # pragma: no cover
-        build_parser.prog = 'grizzly-cli build'
+    if build_parser.prog != 'grizzly-cli dist build':  # pragma: no cover
+        build_parser.prog = 'grizzly-cli dist build'
 
 
 def getuid() -> int:

--- a/grizzly_cli/local.py
+++ b/grizzly_cli/local.py
@@ -1,0 +1,48 @@
+import os
+
+from typing import List, Dict, Any
+from argparse import Namespace as Arguments
+
+from . import register_parser
+from .utils import (
+    run_command,
+)
+from .run import create_parser as run_create_parser, run
+from .argparse import ArgumentSubParser
+
+
+@register_parser(order=2)
+def create_parser(sub_parser: ArgumentSubParser) -> None:
+    local_parser = sub_parser.add_parser('local', description='commands for running grizzly in local mode.')
+
+    if local_parser.prog != 'grizzly-cli local':  # pragma: no cover
+        local_parser.prog = 'grizzly-cli local'
+
+    sub_parser = local_parser.add_subparsers(dest='subcommand')
+
+    run_create_parser(sub_parser, parent='local')
+
+
+def local(args: Arguments) -> int:
+    if args.subcommand == 'run':
+        return run(args, local_run)
+    else:
+        raise ValueError(f'unknown subcommand {args.subcommand}')
+
+
+def local_run(args: Arguments, environ: Dict[str, Any], run_arguments: Dict[str, List[str]]) -> int:
+    for key, value in environ.items():
+        if key not in os.environ:
+            os.environ[key] = value
+
+    command = [
+        'behave',
+    ]
+
+    if args.file is not None:
+        command += [args.file]
+
+    if len(run_arguments.get('master', [])) > 0 or len(run_arguments.get('worker', [])) > 0 or len(run_arguments.get('common', [])) > 0:
+        command += run_arguments['master'] + run_arguments['worker'] + run_arguments['common']
+
+    return run_command(command)

--- a/grizzly_cli/run.py
+++ b/grizzly_cli/run.py
@@ -1,32 +1,21 @@
 import os
-import sys
-import argparse
 
-from typing import List, Dict, Any, cast
-from tempfile import NamedTemporaryFile
-from getpass import getuser
-from shutil import get_terminal_size
+from typing import List, Dict, Any, Callable
 from argparse import Namespace as Arguments
 from platform import node as get_hostname
 
-from . import EXECUTION_CONTEXT, STATIC_CONTEXT, MOUNT_CONTEXT, PROJECT_NAME, register_parser
+from . import EXECUTION_CONTEXT, MOUNT_CONTEXT
 from .utils import (
     find_variable_names_in_questions,
     ask_yes_no, get_input,
     distribution_of_users_per_scenario,
-    is_docker_compose_v2,
     requirements,
-    run_command,
-    get_default_mtu,
-    list_images,
 )
-from .build import build
 from .argparse import ArgumentSubParser
 from .argparse.bashcompletion import BashCompletionTypes
 
 
-@register_parser(order=3)
-def create_parser(sub_parser: ArgumentSubParser) -> None:
+def create_parser(sub_parser: ArgumentSubParser, parent: str) -> None:
     # grizzly-cli run ...
     run_parser = sub_parser.add_parser('run', description='execute load test scenarios specified in a feature file.')
     run_parser.add_argument(
@@ -61,287 +50,20 @@ def create_parser(sub_parser: ArgumentSubParser) -> None:
         default=None,
         help='configuration file with [environment specific information](/grizzly/usage/variables/environment-configuration/)',
     )
-
-    if run_parser.prog != 'grizzly-cli run':  # pragma: no cover
-        run_parser.prog = 'grizzly-cli run'
-
-    run_sub_parser = run_parser.add_subparsers(dest='mode')
-
-    file_kwargs = {
-        'nargs': None,
-        'type': BashCompletionTypes.File('*.feature'),
-        'help': 'path to feature file with one or more scenarios',
-    }
-
-    # grizzly-cli run local ...
-    run_local_parser = run_sub_parser.add_parser('local', description='arguments for running grizzly locally.')
-    run_local_parser.add_argument(
+    run_parser.add_argument(
         'file',
-        **file_kwargs,
+        nargs=None,
+        type=BashCompletionTypes.File('*.feature'),
+        help='path to feature file with one or more scenarios',
+
     )
 
-    if run_local_parser.prog != 'grizzly-cli run local':  # pragma: no cover
-        run_local_parser.prog = 'grizzly-cli run local'
-
-    # grizzly-cli run dist ...
-    run_dist_parser = run_sub_parser.add_parser('dist', description='arguments for running grizzly distributed.')
-    run_dist_parser.add_argument(
-        'file',
-        **file_kwargs,
-    )
-    run_dist_parser.add_argument(
-        '--workers',
-        type=int,
-        required=False,
-        default=1,
-        help='how many instances of the `workers` container that should be created',
-    )
-    run_dist_parser.add_argument(
-        '--container-system',
-        type=str,
-        choices=['podman', 'docker', None],
-        required=False,
-        default=None,
-        help=argparse.SUPPRESS,
-    )
-    run_dist_parser.add_argument(
-        '--id',
-        type=str,
-        required=False,
-        default=None,
-        help='unique identifier suffixed to compose project, should be used when the same user needs to run more than one instance of `grizzly-cli`',
-    )
-    run_dist_parser.add_argument(
-        '--limit-nofile',
-        type=int,
-        required=False,
-        default=10001,
-        help='set system limit "number of open files"',
-    )
-    run_dist_parser.add_argument(
-        '--health-retries',
-        type=int,
-        required=False,
-        default=3,
-        help='set number of retries for health check of master container',
-    )
-    run_dist_parser.add_argument(
-        '--health-timeout',
-        type=int,
-        required=False,
-        default=3,
-        help='set timeout in seconds for health check of master container',
-    )
-    run_dist_parser.add_argument(
-        '--health-interval',
-        type=int,
-        required=False,
-        default=5,
-        help='set interval in seconds between health checks of master container',
-    )
-    run_dist_parser.add_argument(
-        '--registry',
-        type=str,
-        default=None,
-        required=False,
-        help='push built image to this registry, if the registry has authentication you need to login first',
-    )
-    run_dist_parser.add_argument(
-        '--tty',
-        action='store_true',
-        default=False,
-        required=False,
-        help='start containers with a TTY enabled',
-    )
-
-    group_build = run_dist_parser.add_mutually_exclusive_group()
-    group_build.add_argument(
-        '--force-build',
-        action='store_true',
-        required=False,
-        help='force rebuild the grizzly projects container image (no cache)',
-    )
-    group_build.add_argument(
-        '--build',
-        action='store_true',
-        required=False,
-        help='rebuild the grizzly projects container images (with cache)',
-    )
-    group_build.add_argument(
-        '--validate-config',
-        action='store_true',
-        required=False,
-        help='validate and print compose project file',
-    )
-
-    if run_dist_parser.prog != 'grizzly-cli run dist':  # pragma: no cover
-        run_dist_parser.prog = 'grizzly-cli run dist'
-
-
-def distributed(args: Arguments, environ: Dict[str, Any], run_arguments: Dict[str, List[str]]) -> int:
-    suffix = '' if args.id is None else f'-{args.id}'
-    tag = getuser()
-
-    # default locust project
-    compose_args: List[str] = [
-        '-p', f'{PROJECT_NAME}{suffix}-{tag}',
-        '-f', f'{STATIC_CONTEXT}/compose.yaml',
-    ]
-
-    if args.file is not None:
-        os.environ['GRIZZLY_RUN_FILE'] = args.file
-
-    mtu = get_default_mtu(args)
-
-    if mtu is None and os.environ.get('GRIZZLY_MTU', None) is None:
-        print('!! unable to determine MTU, try manually setting GRIZZLY_MTU environment variable if anything other than 1500 is needed')
-        mtu = '1500'
-
-    columns, lines = get_terminal_size()
-
-    # set environment variables needed by compose files, when *-compose executes
-    os.environ['GRIZZLY_MTU'] = cast(str, mtu)
-    os.environ['GRIZZLY_EXECUTION_CONTEXT'] = EXECUTION_CONTEXT
-    os.environ['GRIZZLY_STATIC_CONTEXT'] = STATIC_CONTEXT
-    os.environ['GRIZZLY_MOUNT_CONTEXT'] = MOUNT_CONTEXT
-    os.environ['GRIZZLY_PROJECT_NAME'] = PROJECT_NAME
-    os.environ['GRIZZLY_USER_TAG'] = tag
-    os.environ['GRIZZLY_EXPECTED_WORKERS'] = str(args.workers)
-    os.environ['GRIZZLY_LIMIT_NOFILE'] = str(args.limit_nofile)
-    os.environ['GRIZZLY_HEALTH_CHECK_RETRIES'] = str(args.health_retries)
-    os.environ['GRIZZLY_HEALTH_CHECK_INTERVAL'] = str(args.health_interval)
-    os.environ['GRIZZLY_HEALTH_CHECK_TIMEOUT'] = str(args.health_timeout)
-    os.environ['GRIZZLY_IMAGE_REGISTRY'] = getattr(args, 'registry', None) or ''
-    os.environ['GRIZZLY_CONTAINER_TTY'] = 'true' if args.tty else 'false'
-    os.environ['COLUMNS'] = str(columns)
-    os.environ['LINES'] = str(lines)
-
-    if len(run_arguments.get('master', [])) > 0:
-        os.environ['GRIZZLY_MASTER_RUN_ARGS'] = ' '.join(run_arguments['master'])
-
-    if len(run_arguments.get('worker', [])) > 0:
-        os.environ['GRIZZLY_WORKER_RUN_ARGS'] = ' '.join(run_arguments['worker'])
-
-    if len(run_arguments.get('common', [])) > 0:
-        os.environ['GRIZZLY_COMMON_RUN_ARGS'] = ' '.join(run_arguments['common'])
-
-    # check if we need to build image
-    images = list_images(args)
-
-    with NamedTemporaryFile() as fd:
-        # file will be deleted when conContainertext exits
-        if len(environ) > 0:
-            for key, value in environ.items():
-                if key == 'GRIZZLY_CONFIGURATION_FILE':
-                    value = value.replace(EXECUTION_CONTEXT, MOUNT_CONTEXT).replace(MOUNT_CONTEXT, '/srv/grizzly')
-
-                fd.write(f'{key}={value}\n'.encode('utf-8'))
-
-        fd.write(f'COLUMNS={columns}\n'.encode('utf-8'))
-        fd.write(f'LINES={lines}\n'.encode('utf-8'))
-        fd.write(f'GRIZZLY_CONTAINER_TTY={os.environ["GRIZZLY_CONTAINER_TTY"]}\n'.encode('utf-8'))
-
-        fd.flush()
-
-        os.environ['GRIZZLY_ENVIRONMENT_FILE'] = fd.name
-
-        validate_config = getattr(args, 'validate_config', False)
-
-        compose_command = [
-            f'{args.container_system}-compose',
-            *compose_args,
-            'config',
-        ]
-
-        rc = run_command(compose_command, silent=not validate_config)
-
-        if validate_config or rc != 0:
-            if rc != 0 and not validate_config:
-                print('!! something in the compose project is not valid, check with:')
-                print(f'grizzly-cli {" ".join(sys.argv[1:])} --validate-config')
-
-            return rc
-
-        if images.get(PROJECT_NAME, {}).get(tag, None) is None or args.force_build or args.build:
-            rc = build(args)
-            if rc != 0:
-                print(f'!! failed to build {PROJECT_NAME}, rc={rc}')
-                return rc
-
-        compose_scale_argument = ['--scale', f'worker={args.workers}']
-
-        # bring up containers
-        compose_command = [
-            f'{args.container_system}-compose',
-            *compose_args,
-            'up',
-            *compose_scale_argument,
-            '--remove-orphans',
-        ]
-
-        rc = run_command(compose_command, verbose=args.verbose)
-
-        # stop containers
-        compose_command = [
-            f'{args.container_system}-compose',
-            *compose_args,
-            'stop',
-        ]
-
-        run_command(compose_command)
-
-        if rc != 0:
-            print('\n!! something went wrong, check container logs with:')
-            template = '{container_system} container logs '
-            if is_docker_compose_v2():
-                template += '{project}{suffix}-{tag}-{node}-{index}'
-                start_index = 2
-            else:
-                template += '{project}{suffix}-{tag}_{node}_{index}'
-                start_index = 1
-
-            print(template.format(
-                container_system=args.container_system,
-                project=PROJECT_NAME,
-                suffix=suffix,
-                tag=tag,
-                node='master',
-                index=1
-            ))
-
-            for worker in range(start_index, args.workers + start_index):
-                print(template.format(
-                    container_system=args.container_system,
-                    project=PROJECT_NAME,
-                    suffix=suffix,
-                    tag=tag,
-                    node='worker',
-                    index=worker
-                ))
-
-        return rc
-
-
-def local(args: Arguments, environ: Dict[str, Any], run_arguments: Dict[str, List[str]]) -> int:
-    for key, value in environ.items():
-        if key not in os.environ:
-            os.environ[key] = value
-
-    command = [
-        'behave',
-    ]
-
-    if args.file is not None:
-        command += [args.file]
-
-    if len(run_arguments.get('master', [])) > 0 or len(run_arguments.get('worker', [])) > 0 or len(run_arguments.get('common', [])) > 0:
-        command += run_arguments['master'] + run_arguments['worker'] + run_arguments['common']
-
-    return run_command(command)
+    if run_parser.prog != f'grizzly-cli {parent} run':  # pragma: no cover
+        run_parser.prog = f'grizzly-cli {parent} run'
 
 
 @requirements(EXECUTION_CONTEXT)
-def run(args: Arguments) -> int:
+def run(args: Arguments, run_func: Callable[[Arguments, Dict[str, Any], Dict[str, List[str]]], int]) -> int:
     # always set hostname of host where grizzly-cli was executed, could be useful
     environ: Dict[str, Any] = {
         'GRIZZLY_CLI_HOST': get_hostname(),
@@ -381,11 +103,6 @@ def run(args: Arguments) -> int:
     if not getattr(args, 'validate_config', False):
         distribution_of_users_per_scenario(args, environ)
 
-    if args.mode == 'dist':
-        run = distributed
-    else:
-        run = local
-
     run_arguments: Dict[str, List[str]] = {
         'master': [],
         'worker': [],
@@ -395,4 +112,4 @@ def run(args: Arguments) -> int:
     if args.verbose:
         run_arguments['common'] += ['--verbose', '--no-logcapture', '--no-capture', '--no-capture-stderr']
 
-    return run(args, environ, run_arguments)
+    return run_func(args, environ, run_arguments)

--- a/grizzly_cli/utils.py
+++ b/grizzly_cli/utils.py
@@ -356,10 +356,10 @@ def get_default_mtu(args: Arguments) -> Optional[str]:
         return None
 
 
-def requirements(execution_context: str) -> Callable[[Callable[[Arguments], int]], Callable[[Arguments], int]]:
-    def wrapper(func: Callable[[Arguments], int]) -> Callable[[Arguments], int]:
+def requirements(execution_context: str) -> Callable[[Callable[..., int]], Callable[..., int]]:
+    def wrapper(func: Callable[..., int]) -> Callable[..., int]:
         @wraps(func)
-        def _wrapper(arguments: Arguments) -> int:
+        def _wrapper(*args: Tuple[Any, ...], **kwargs: Dict[str, Any]) -> int:
             requirements_file = path.join(getattr(func, '__value__'), 'requirements.txt')
             if not path.exists(requirements_file):
                 with open(requirements_file, 'w+') as fd:
@@ -368,7 +368,7 @@ def requirements(execution_context: str) -> Callable[[Callable[[Arguments], int]
                 print('!! created a default requirements.txt with one dependency:')
                 print('grizzly-loadtester\n')
 
-            return func(arguments)
+            return func(*args, **kwargs)
 
         # a bit ugly, but needed for testability
         setattr(func, '__value__', execution_context)

--- a/tests/argparse/bashcompletion/test__init__.py
+++ b/tests/argparse/bashcompletion/test__init__.py
@@ -1,8 +1,8 @@
 import argparse
 import inspect
 
-from typing import Optional, Generator, cast
-from os import path, chdir, getcwd, sep
+from typing import Optional, Generator
+from os import path, chdir, getcwd
 from shutil import rmtree
 
 import pytest
@@ -222,10 +222,10 @@ class TestBashCompleteAction:
     @pytest.mark.parametrize(
         'input,expected',
         [
-            ('grizzly-cli ', '-h --help --version init build run',),
+            ('grizzly-cli ', '-h --help --version init local dist',),
             ('grizzly-cli -', '-h --help --version'),
             ('grizzly-cli --', '--help --version'),
-            ('grizzly-cli ru', 'run'),
+            ('grizzly-cli lo', 'local'),
             ('grizzly-cli -h', ''),
         ]
     )
@@ -238,32 +238,34 @@ class TestBashCompleteAction:
         assert capture.out == f'{expected}\n'
 
     @pytest.mark.parametrize(
-        'input,expected',
-        [
-            ('grizzly-cli run ', '-h --help --verbose -T --testdata-variable -y --yes -e --environment-file local dist'),
-            ('grizzly-cli run -', '-h --help --verbose -T --testdata-variable -y --yes -e --environment-file'),
-            ('grizzly-cli run --', '--help --verbose --testdata-variable --yes --environment-file'),
-            ('grizzly-cli run --yes', '-h --help --verbose -T --testdata-variable -e --environment-file local dist'),
-            ('grizzly-cli run --help --yes', ''),
-            ('grizzly-cli run --yes -T', ''),
-            ('grizzly-cli run --yes -T key=value', '-h --help --verbose -T --testdata-variable -e --environment-file local dist'),
-            ('grizzly-cli run --yes -T key=value --env', '--environment-file'),
-            ('grizzly-cli run --yes -T key=value --environment-file', 'test.yaml test-dir'),
-            ('grizzly-cli run --yes -T key=value --environment-file test', 'test.yaml test-dir'),
-            ('grizzly-cli run --yes -T key=value --environment-file test-', 'test-dir'),
-            ('grizzly-cli run --yes -T key=value --environment-file test-dir', '-h --help --verbose -T --testdata-variable local dist'),
-            ('grizzly-cli run --yes -T key=value --environment-file test.', 'test.yaml'),
-            ('grizzly-cli run --yes -T key=value --environment-file test.yaml', '-h --help --verbose -T --testdata-variable local dist'),
-            ('grizzly-cli run --yes -T key=value --environment-file test.yaml --test', '--testdata-variable'),
-            ('grizzly-cli run --yes -T key=value --environment-file test.yaml --testdata-variable', ''),
-            ('grizzly-cli run --yes -T key=value --environment-file test.yaml --testdata-variable key=value', '-h --help --verbose -T --testdata-variable local dist'),
-            ('grizzly-cli run --yes -T key=value --environment-file test.yaml --testdata-variable key=value l', 'local'),
-            ('grizzly-cli run --yes -T key=value --environment-file test.yaml --testdata-variable key=value d', 'dist'),
-            ('grizzly-cli run --yes -T key=value --environment-file test.yaml --testdata-variable key=value --help', ''),
-            ('grizzly-cli run --yes -T key=value --environment-file test.yaml --testdata-variable key=value --help d', ''),
+        'input,expected', [
+            ('grizzly-cli local run ', '-h --help --verbose -T --testdata-variable -y --yes -e --environment-file test.feature test-dir'),
+            ('grizzly-cli local run -', '-h --help --verbose -T --testdata-variable -y --yes -e --environment-file'),
+            ('grizzly-cli local run --', '--help --verbose --testdata-variable --yes --environment-file'),
+            ('grizzly-cli local run --yes', '-h --help --verbose -T --testdata-variable -e --environment-file'),
+            ('grizzly-cli local run --help --yes', ''),
+            ('grizzly-cli local run --yes -T', ''),
+            ('grizzly-cli local run --yes -T key=value', '-h --help --verbose -T --testdata-variable -e --environment-file test.feature test-dir'),
+            ('grizzly-cli local run --yes -T key=value --env', '--environment-file'),
+            ('grizzly-cli local run --yes -T key=value --environment-file', 'test.yaml test-dir'),
+            ('grizzly-cli local run --yes -T key=value --environment-file test', 'test.yaml test-dir'),
+            ('grizzly-cli local run --yes -T key=value --environment-file test-', 'test-dir'),
+            ('grizzly-cli local run --yes -T key=value --environment-file test-dir', '-h --help --verbose -T --testdata-variable'),
+            ('grizzly-cli local run --yes -T key=value --environment-file test.', 'test.yaml'),
+            ('grizzly-cli local run --yes -T key=value --environment-file test.yaml', '-h --help --verbose -T --testdata-variable'),
+            ('grizzly-cli local run --yes -T key=value --environment-file test.yaml --test', '--testdata-variable'),
+            ('grizzly-cli local run --yes -T key=value --environment-file test.yaml --testdata-variable', ''),
+            (
+                'grizzly-cli local run --yes -T key=value --environment-file test.yaml --testdata-variable key=value',
+                '-h --help --verbose -T --testdata-variable test.feature test-dir',
+            ),
+            ('grizzly-cli local run --yes -T key=value --environment-file test.yaml --testdata-variable key=value test', 'test.feature test-dir'),
+            ('grizzly-cli local run --yes -T key=value --environment-file test.yaml --testdata-variable key=value test.fe', 'test.feature'),
+            ('grizzly-cli local run --yes -T key=value --environment-file test.yaml --testdata-variable key=value --help', ''),
+            ('grizzly-cli local run --yes -T key=value --environment-file test.yaml --testdata-variable key=value --help d', ''),
         ]
     )
-    def test___call___run(self, input: str, expected: str, capsys: CaptureFixture, test_file_structure: None) -> None:
+    def test___call___local_run(self, input: str, expected: str, capsys: CaptureFixture, test_file_structure: None) -> None:
         capture: Optional[CaptureResult] = None
 
         try:
@@ -272,170 +274,157 @@ class TestBashCompleteAction:
             _subparsers = getattr(parser, '_subparsers', None)
             assert _subparsers is not None
             subparser: Optional[argparse.ArgumentParser]
-            for subparsers in _subparsers._group_actions:
-                for name, subparser in subparsers.choices.items():
-                    if name == 'run':
-                        break
-
-            assert subparser is not None
-            assert subparser.prog == 'grizzly-cli run'
-
-            with pytest.raises(SystemExit):
-                subparser.parse_args([f'--bash-complete={input}'])
-            capture = capsys.readouterr()
-            assert capture.out == f'{expected}\n'
-        except:
-            print(f'input={input}')
-            print(f'expected={expected}')
-            if capture is not None:
-                print(f'actual={capture.out}')
-            raise
-        finally:
-            chdir(CWD)
-
-    @pytest.mark.parametrize(
-        'input,expected',
-        [
-            (
-                'grizzly-cli run --yes -T key=value --environment-file test.yaml --testdata-variable key=value dist',
-                (
-                    '-h --help --workers --id --limit-nofile --health-retries --health-timeout --health-interval --registry '
-                    '--tty --force-build --build --validate-config test.feature test-dir'
-                )
-            ),
-            (
-                'grizzly-cli run --yes -T key=value --environment-file test.yaml --testdata-variable key=value dist -',
-                '-h --help --workers --id --limit-nofile --health-retries --health-timeout --health-interval --registry --tty --force-build --build --validate-config',
-            ),
-            (
-                'grizzly-cli run --yes -T key=value --environment-file test.yaml --testdata-variable key=value dist --',
-                '--help --workers --id --limit-nofile --health-retries --health-timeout --health-interval --registry --tty --force-build --build --validate-config',
-            ),
-            (
-                'grizzly-cli run --yes -T key=value --environment-file test.yaml --testdata-variable key=value dist --workers',
-                '',
-            ),
-            (
-                'grizzly-cli run --yes -T key=value --environment-file test.yaml --testdata-variable key=value dist --workers asdf',
-                '',
-            ),
-            (
-                'grizzly-cli run --yes -T key=value --environment-file test.yaml --testdata-variable key=value dist --workers 8',
-                '-h --help --id --limit-nofile --health-retries --health-timeout --health-interval --registry --tty --force-build --build --validate-config',
-            ),
-            (
-                'grizzly-cli run --yes -T key=value --environment-file test.yaml --testdata-variable key=value dist --workers 8 --force-build',
-                '-h --help --id --limit-nofile --health-retries --health-timeout --health-interval --registry --tty test.feature test-dir',
-            ),
-            (
-                'grizzly-cli run --yes -T key=value --environment-file test.yaml --testdata-variable key=value dist --workers 8 --force-build test',
-                'test.feature test-dir',
-            ),
-            (
-                'grizzly-cli run --yes -T key=value --environment-file test.yaml --testdata-variable key=value dist --workers 8 --force-build test.',
-                'test.feature',
-            ),
-            (
-                'grizzly-cli run --yes -T key=value --environment-file test.yaml --testdata-variable key=value dist --workers 8 --force-build test.feature',
-                '-h --help --id --limit-nofile --health-retries --health-timeout --health-interval --registry --tty',
-            ),
-            (
-                'grizzly-cli run --yes -T key=value --environment-file test.yaml --testdata-variable key=value dist --workers 8 -h --force-build',
-                '',
-            ),
-        ]
-    )
-    def test___call___run_dist(self, input: str, expected: str, capsys: CaptureFixture, test_file_structure: None) -> None:
-        capture: Optional[CaptureResult] = None
-
-        try:
-            parser = _create_parser()
-            hook(parser)
-            _subparsers = getattr(parser, '_subparsers', None)
-            assert _subparsers is not None
-            subparser: Optional[argparse.ArgumentParser]
-            for subparsers in _subparsers._group_actions:
-                for name, subparser in subparsers.choices.items():
-                    if name == 'run':
-                        break
-
-            assert subparser is not None
-            parser = cast(ArgumentParser, subparser)
-            _subparsers = getattr(parser, '_subparsers', None)
-            assert _subparsers is not None
-            for subparsers in _subparsers._group_actions:
-                for name, subparser in subparsers.choices.items():
-                    if name == 'dist':
-                        break
-            assert subparser is not None
-            assert subparser.prog == 'grizzly-cli run dist'
-
-            with pytest.raises(SystemExit):
-                subparser.parse_args([f'--bash-complete={input}'])
-            capture = capsys.readouterr()
-            assert capture.out == f'{expected}\n'
-        except:
-            print(f'input={input}')
-            print(f'expected={expected}')
-            if capture is not None:
-                print(f'actual={capture.out}')
-            raise
-        finally:
-            chdir(CWD)
-
-    @pytest.mark.parametrize(
-        'input,expected',
-        [
-            (
-                'grizzly-cli run --yes -T key=value --environment-file test.yaml --testdata-variable key=value local',
-                '-h --help test.feature test-dir',
-            ),
-            (
-                'grizzly-cli run --yes -T key=value --environment-file test.yaml --testdata-variable key=value local -',
-                '-h --help',
-            ),
-            (
-                'grizzly-cli run --yes -T key=value --environment-file test.yaml --testdata-variable key=value local --help',
-                '',
-            ),
-            (
-                'grizzly-cli run --yes -T key=value --environment-file test.yaml --testdata-variable key=value local ---help',
-                '-h --help test.feature test-dir',
-            ),
-            (
-                'grizzly-cli run --yes -T key=value --environment-file test.yaml --testdata-variable key=value local test',
-                'test.feature test-dir',
-            ),
-            (
-                f'grizzly-cli run --yes -T key=value --environment-file test.yaml --testdata-variable key=value local test-dir{sep}',
-                f'test-dir{sep}test.feature',
-            ),
-        ]
-    )
-    def test___call___run_local(self, input: str, expected: str, capsys: CaptureFixture, test_file_structure: None) -> None:
-        capture: Optional[CaptureResult] = None
-
-        try:
-            parser = _create_parser()
-            hook(parser)
-            _subparsers = getattr(parser, '_subparsers', None)
-            assert _subparsers is not None
-            subparser: Optional[argparse.ArgumentParser]
-            for subparsers in _subparsers._group_actions:
-                for name, subparser in subparsers.choices.items():
-                    if name == 'run':
-                        break
-
-            assert subparser is not None
-            parser = cast(ArgumentParser, subparser)
-            _subparsers = getattr(parser, '_subparsers', None)
-            assert _subparsers is not None
             for subparsers in _subparsers._group_actions:
                 for name, subparser in subparsers.choices.items():
                     if name == 'local':
                         break
+
             assert subparser is not None
-            assert subparser.prog == 'grizzly-cli run local'
+            assert subparser.prog == 'grizzly-cli local'
+
+            _subparsers = getattr(subparser, '_subparsers', None)
+            assert _subparsers is not None
+            for subparsers in _subparsers._group_actions:
+                for name, subparser in subparsers.choices.items():
+                    if name == 'run':
+                        break
+
+            assert subparser is not None
+            assert subparser.prog == 'grizzly-cli local run'
+
+            with pytest.raises(SystemExit):
+                subparser.parse_args([f'--bash-complete={input}'])
+            capture = capsys.readouterr()
+            assert capture.out == f'{expected}\n'
+        except:
+            print(f'input={input}')
+            print(f'expected={expected}')
+            if capture is not None:
+                print(f'actual={capture.out}')
+            raise
+        finally:
+            chdir(CWD)
+
+    @pytest.mark.parametrize(
+        'input,expected', [
+            ('grizzly-cli dist run ', '-h --help --verbose -T --testdata-variable -y --yes -e --environment-file test.feature test-dir'),
+            ('grizzly-cli dist run -', '-h --help --verbose -T --testdata-variable -y --yes -e --environment-file'),
+            ('grizzly-cli dist run --', '--help --verbose --testdata-variable --yes --environment-file'),
+            ('grizzly-cli dist run --yes', '-h --help --verbose -T --testdata-variable -e --environment-file'),
+            ('grizzly-cli dist run --help --yes', ''),
+            ('grizzly-cli dist run --yes -T', ''),
+            ('grizzly-cli dist run --yes -T key=value', '-h --help --verbose -T --testdata-variable -e --environment-file test.feature test-dir'),
+            ('grizzly-cli dist run --yes -T key=value --env', '--environment-file'),
+            ('grizzly-cli dist run --yes -T key=value --environment-file', 'test.yaml test-dir'),
+            ('grizzly-cli dist run --yes -T key=value --environment-file test', 'test.yaml test-dir'),
+            ('grizzly-cli dist run --yes -T key=value --environment-file test-', 'test-dir'),
+            ('grizzly-cli dist run --yes -T key=value --environment-file test-dir', '-h --help --verbose -T --testdata-variable'),
+            ('grizzly-cli dist run --yes -T key=value --environment-file test.', 'test.yaml'),
+            ('grizzly-cli dist run --yes -T key=value --environment-file test.yaml', '-h --help --verbose -T --testdata-variable'),
+            ('grizzly-cli dist run --yes -T key=value --environment-file test.yaml --test', '--testdata-variable'),
+            ('grizzly-cli dist run --yes -T key=value --environment-file test.yaml --testdata-variable', ''),
+            (
+                'grizzly-cli dist run --yes -T key=value --environment-file test.yaml --testdata-variable key=value',
+                '-h --help --verbose -T --testdata-variable test.feature test-dir',
+            ),
+            ('grizzly-cli dist run --yes -T key=value --environment-file test.yaml --testdata-variable key=value test', 'test.feature test-dir'),
+            ('grizzly-cli dist run --yes -T key=value --environment-file test.yaml --testdata-variable key=value test.fe', 'test.feature'),
+            ('grizzly-cli dist run --yes -T key=value --environment-file test.yaml --testdata-variable key=value --help', ''),
+            ('grizzly-cli dist run --yes -T key=value --environment-file test.yaml --testdata-variable key=value --help d', ''),
+        ]
+    )
+    def test___call___dist_run(self, input: str, expected: str, capsys: CaptureFixture, test_file_structure: None) -> None:
+        capture: Optional[CaptureResult] = None
+
+        try:
+            parser = _create_parser()
+            hook(parser)
+            _subparsers = getattr(parser, '_subparsers', None)
+            assert _subparsers is not None
+            subparser: Optional[argparse.ArgumentParser]
+            for subparsers in _subparsers._group_actions:
+                for name, subparser in subparsers.choices.items():
+                    if name == 'dist':
+                        break
+
+            assert subparser is not None
+            assert subparser.prog == 'grizzly-cli dist'
+
+            _subparsers = getattr(subparser, '_subparsers', None)
+            assert _subparsers is not None
+            for subparsers in _subparsers._group_actions:
+                for name, subparser in subparsers.choices.items():
+                    if name == 'run':
+                        break
+
+            assert subparser is not None
+            assert subparser.prog == 'grizzly-cli dist run'
+
+            with pytest.raises(SystemExit):
+                subparser.parse_args([f'--bash-complete={input}'])
+            capture = capsys.readouterr()
+            assert capture.out == f'{expected}\n'
+        except:
+            print(f'input={input}')
+            print(f'expected={expected}')
+            if capture is not None:
+                print(f'actual={capture.out}')
+            raise
+        finally:
+            chdir(CWD)
+
+    @pytest.mark.parametrize(
+        'input,expected',
+        [
+            (
+                'grizzly-cli dist',
+                (
+                    '-h --help --workers --id --limit-nofile --health-retries --health-timeout --health-interval --registry '
+                    '--tty --force-build --build --validate-config build run'
+                )
+            ),
+            (
+                'grizzly-cli dist -',
+                '-h --help --workers --id --limit-nofile --health-retries --health-timeout --health-interval --registry --tty --force-build --build --validate-config',
+            ),
+            (
+                'grizzly-cli dist --',
+                '--help --workers --id --limit-nofile --health-retries --health-timeout --health-interval --registry --tty --force-build --build --validate-config',
+            ),
+            (
+                'grizzly-cli dist --workers',
+                '',
+            ),
+            (
+                'grizzly-cli dist --workers asdf',
+                '',
+            ),
+            (
+                'grizzly-cli dist --workers 8',
+                '-h --help --id --limit-nofile --health-retries --health-timeout --health-interval --registry --tty --force-build --build --validate-config build run',
+            ),
+            (
+                'grizzly-cli dist --workers 8 --force-build',
+                '-h --help --id --limit-nofile --health-retries --health-timeout --health-interval --registry --tty build run',
+            ),
+        ],
+    )
+    def test___call__dist(self, input: str, expected: str, capsys: CaptureFixture, test_file_structure: None) -> None:
+        capture: Optional[CaptureResult] = None
+
+        try:
+            parser = _create_parser()
+            hook(parser)
+            _subparsers = getattr(parser, '_subparsers', None)
+            assert _subparsers is not None
+            subparser: Optional[argparse.ArgumentParser]
+            for subparsers in _subparsers._group_actions:
+                for name, subparser in subparsers.choices.items():
+                    if name == 'dist':
+                        break
+
+            assert subparser is not None
+            assert subparser.prog == 'grizzly-cli dist'
 
             with pytest.raises(SystemExit):
                 subparser.parse_args([f'--bash-complete={input}'])

--- a/tests/distributed/test___init__.py
+++ b/tests/distributed/test___init__.py
@@ -1,0 +1,297 @@
+from shutil import rmtree
+from os import getcwd, environ
+from tempfile import gettempdir
+from argparse import ArgumentParser, Namespace
+
+import pytest
+
+from _pytest.capture import CaptureFixture
+from _pytest.tmpdir import TempPathFactory
+from pytest_mock import MockerFixture
+
+from grizzly_cli.distributed import create_parser, distributed_run, distributed
+
+from ..helpers import onerror
+
+CWD = getcwd()
+
+
+def test_distributed(mocker: MockerFixture) -> None:
+    run_mocked = mocker.patch('grizzly_cli.distributed.run', return_value=0)
+    build_mocked = mocker.patch('grizzly_cli.distributed.do_build', return_value=5)
+
+    arguments = Namespace(subcommand='run')
+    assert distributed(arguments) == 0
+
+    assert run_mocked.call_count == 1
+    args, _ = run_mocked.call_args_list[0]
+    assert args[0] is arguments
+    assert args[1] is distributed_run
+
+    assert build_mocked.call_count == 0
+
+    arguments = Namespace(subcommand='build')
+    assert distributed(arguments) == 5
+
+    assert run_mocked.call_count == 1
+    assert build_mocked.call_count == 1
+    args, _ = build_mocked.call_args_list[0]
+    assert args[0] is arguments
+
+    arguments = Namespace(subcommand='foo')
+    with pytest.raises(ValueError) as ve:
+        distributed(arguments)
+    assert 'unknown subcommand foo' == str(ve.value)
+
+
+def test_distributed_run(capsys: CaptureFixture, mocker: MockerFixture, tmp_path_factory: TempPathFactory) -> None:
+    test_context = tmp_path_factory.mktemp('test_context')
+    (test_context / 'test.feature').write_text('Feature:')
+
+    mocker.patch('grizzly_cli.distributed.getuser', return_value='test-user')
+    mocker.patch('grizzly_cli.distributed.get_default_mtu', side_effect=['1500', None, '1400', '1330', '1800'])
+    mocker.patch('grizzly_cli.distributed.do_build', side_effect=[255, 0, 0])
+    mocker.patch('grizzly_cli.distributed.list_images', side_effect=[{}, {}, {}, {'grizzly-cli-test-project': {'test-user': {}}}, {'grizzly-cli-test-project': {'test-user': {}}}])
+
+    import grizzly_cli.distributed
+    mocker.patch.object(grizzly_cli.distributed, 'EXECUTION_CONTEXT', '/tmp/execution-context')
+    mocker.patch.object(grizzly_cli.distributed, 'STATIC_CONTEXT', '/tmp/static-context')
+    mocker.patch.object(grizzly_cli.distributed, 'MOUNT_CONTEXT', '/tmp/mount-context')
+    mocker.patch.object(grizzly_cli.distributed, 'PROJECT_NAME', 'grizzly-cli-test-project')
+
+    mocker.patch('grizzly_cli.distributed.is_docker_compose_v2', return_value=False)
+
+    run_command_mock = mocker.patch('grizzly_cli.distributed.run_command', side_effect=[111, 0, 0, 1, 0, 0, 1, 0, 13])
+
+    parser = ArgumentParser()
+
+    sub_parsers = parser.add_subparsers(dest='test')
+
+    create_parser(sub_parsers)
+
+    try:
+        arguments = parser.parse_args(['dist', '--workers', '3', '--tty', 'run', f'{test_context}/test.feature'])
+        setattr(arguments, 'container_system', 'docker')
+
+        # this is set in the devcontainer
+        for key in environ.keys():
+            if key.startswith('GRIZZLY_'):
+                del environ[key]
+
+        assert distributed_run(arguments, {}, {}) == 111
+        capture = capsys.readouterr()
+        import sys
+        assert capture.err == ''
+        assert capture.out == (
+            '!! something in the compose project is not valid, check with:\n'
+            f'grizzly-cli {" ".join(sys.argv[1:])} --validate-config\n'
+        )
+
+        try:
+            del environ['GRIZZLY_MTU']
+        except KeyError:
+            pass
+
+        assert distributed_run(arguments, {}, {}) == 255
+        capture = capsys.readouterr()
+        assert capture.err == ''
+        assert capture.out == (
+            '!! unable to determine MTU, try manually setting GRIZZLY_MTU environment variable if anything other than 1500 is needed\n'
+            '!! failed to build grizzly-cli-test-project, rc=255\n'
+        )
+        assert environ.get('GRIZZLY_MTU', None) == '1500'
+        assert environ.get('GRIZZLY_EXECUTION_CONTEXT', None) == '/tmp/execution-context'
+        assert environ.get('GRIZZLY_STATIC_CONTEXT', None) == '/tmp/static-context'
+        assert environ.get('GRIZZLY_MOUNT_CONTEXT', None) == '/tmp/mount-context'
+        assert environ.get('GRIZZLY_PROJECT_NAME', None) == 'grizzly-cli-test-project'
+        assert environ.get('GRIZZLY_USER_TAG', None) == 'test-user'
+        assert environ.get('GRIZZLY_EXPECTED_WORKERS', None) == '3'
+        assert environ.get('GRIZZLY_MASTER_RUN_ARGS', None) is None
+        assert environ.get('GRIZZLY_WORKER_RUN_ARGS', None) is None
+        assert environ.get('GRIZZLY_COMMON_RUN_ARGS', None) is None
+        assert environ.get('GRIZZLY_IMAGE_REGISTRY', None) == ''
+        assert environ.get('GRIZZLY_ENVIRONMENT_FILE', '').startswith(gettempdir())
+        assert environ.get('GRIZZLY_LIMIT_NOFILE', None) == '10001'
+        assert environ.get('GRIZZLY_HEALTH_CHECK_INTERVAL', None) == '5'
+        assert environ.get('GRIZZLY_HEALTH_CHECK_TIMEOUT', None) == '3'
+        assert environ.get('GRIZZLY_HEALTH_CHECK_RETRIES', None) == '3'
+        assert environ.get('GRIZZLY_CONTAINER_TTY', None) == 'true'
+
+        # this is set in the devcontainer
+        for key in environ.keys():
+            if key.startswith('GRIZZLY_'):
+                del environ[key]
+
+        arguments = parser.parse_args([
+            'dist',
+            '--workers', '3',
+            '--build',
+            '--limit-nofile', '133700',
+            '--health-interval', '10',
+            '--health-timeout', '8',
+            '--health-retries', '30',
+            '--registry', 'gchr.io/biometria-se',
+            'run',
+            f'{test_context}/test.feature',
+        ])
+        setattr(arguments, 'container_system', 'docker')
+
+        mocker.patch('grizzly_cli.distributed.is_docker_compose_v2', side_effect=[True, False])
+
+        # docker-compose v2
+        assert distributed_run(
+            arguments,
+            {
+                'GRIZZLY_CONFIGURATION_FILE': '/tmp/execution-context/configuration.yaml',
+                'GRIZZLY_TEST_VAR': 'True',
+            },
+            {
+                'master': ['--foo', 'bar', '--master'],
+                'worker': ['--bar', 'foo', '--worker'],
+                'common': ['--common', 'true'],
+            },
+        ) == 1
+        capture = capsys.readouterr()
+        assert capture.err == ''
+        assert capture.out == (
+            '\n!! something went wrong, check container logs with:\n'
+            'docker container logs grizzly-cli-test-project-test-user-master-1\n'
+            'docker container logs grizzly-cli-test-project-test-user-worker-2\n'
+            'docker container logs grizzly-cli-test-project-test-user-worker-3\n'
+            'docker container logs grizzly-cli-test-project-test-user-worker-4\n'
+        )
+
+        assert run_command_mock.call_count == 5
+        args, _ = run_command_mock.call_args_list[-3]
+        assert args[0] == [
+            'docker-compose',
+            '-p', 'grizzly-cli-test-project-test-user',
+            '-f', '/tmp/static-context/compose.yaml',
+            'config',
+        ]
+        args, _ = run_command_mock.call_args_list[-2]
+        assert args[0] == [
+            'docker-compose',
+            '-p', 'grizzly-cli-test-project-test-user',
+            '-f', '/tmp/static-context/compose.yaml',
+            'up',
+            '--scale', 'worker=3',
+            '--remove-orphans',
+        ]
+        args, _ = run_command_mock.call_args_list[-1]
+        assert args[0] == [
+            'docker-compose',
+            '-p', 'grizzly-cli-test-project-test-user',
+            '-f', '/tmp/static-context/compose.yaml',
+            'stop',
+        ]
+
+        assert environ.get('GRIZZLY_RUN_FILE', None) == f'{test_context}/test.feature'
+        assert environ.get('GRIZZLY_MTU', None) == '1400'
+        assert environ.get('GRIZZLY_EXECUTION_CONTEXT', None) == '/tmp/execution-context'
+        assert environ.get('GRIZZLY_STATIC_CONTEXT', None) == '/tmp/static-context'
+        assert environ.get('GRIZZLY_MOUNT_CONTEXT', None) == '/tmp/mount-context'
+        assert environ.get('GRIZZLY_PROJECT_NAME', None) == 'grizzly-cli-test-project'
+        assert environ.get('GRIZZLY_USER_TAG', None) == 'test-user'
+        assert environ.get('GRIZZLY_EXPECTED_WORKERS', None) == '3'
+        assert environ.get('GRIZZLY_MASTER_RUN_ARGS', None) == '--foo bar --master'
+        assert environ.get('GRIZZLY_WORKER_RUN_ARGS', None) == '--bar foo --worker'
+        assert environ.get('GRIZZLY_COMMON_RUN_ARGS', None) == '--common true'
+        assert environ.get('GRIZZLY_ENVIRONMENT_FILE', '').startswith(gettempdir())
+        assert environ.get('GRIZZLY_LIMIT_NOFILE', None) == '133700'
+        assert environ.get('GRIZZLY_HEALTH_CHECK_INTERVAL', None) == '10'
+        assert environ.get('GRIZZLY_HEALTH_CHECK_TIMEOUT', None) == '8'
+        assert environ.get('GRIZZLY_HEALTH_CHECK_RETRIES', None) == '30'
+        assert environ.get('GRIZZLY_IMAGE_REGISTRY', None) == 'gchr.io/biometria-se'
+        assert environ.get('GRIZZLY_CONTAINER_TTY', None) == 'false'
+
+        # docker-compose v1
+        assert distributed_run(
+            arguments,
+            {
+                'GRIZZLY_CONFIGURATION_FILE': '/tmp/execution-context/configuration.yaml',
+                'GRIZZLY_TEST_VAR': 'True',
+            },
+            {
+                'master': ['--foo', 'bar', '--master'],
+                'worker': ['--bar', 'foo', '--worker'],
+                'common': ['--common', 'true'],
+            },
+        ) == 1
+        capture = capsys.readouterr()
+        assert capture.err == ''
+        assert capture.out == (
+            '\n!! something went wrong, check container logs with:\n'
+            'docker container logs grizzly-cli-test-project-test-user_master_1\n'
+            'docker container logs grizzly-cli-test-project-test-user_worker_1\n'
+            'docker container logs grizzly-cli-test-project-test-user_worker_2\n'
+            'docker container logs grizzly-cli-test-project-test-user_worker_3\n'
+        )
+
+        mocker.patch('grizzly_cli.distributed.is_docker_compose_v2', return_value=False)
+
+        # this is set in the devcontainer
+        for key in environ.keys():
+            if key.startswith('GRIZZLY_'):
+                del environ[key]
+
+        arguments = parser.parse_args([
+            'dist',
+            '--workers', '1',
+            '--id', 'suffix',
+            '--validate-config',
+            '--limit-nofile', '20000',
+            '--health-interval', '10',
+            '--health-timeout', '8',
+            '--health-retries', '30',
+            'run', f'{test_context}/test.feature',
+        ])
+        setattr(arguments, 'container_system', 'docker')
+
+        assert distributed_run(
+            arguments,
+            {
+                'GRIZZLY_CONFIGURATION_FILE': '/tmp/execution-context/configuration.yaml',
+                'GRIZZLY_TEST_VAR': 'True',
+            },
+            {
+                'master': ['--foo', 'bar', '--master'],
+                'worker': ['--bar', 'foo', '--worker'],
+                'common': ['--common', 'true'],
+            },
+        ) == 13
+        capture = capsys.readouterr()
+        assert capture.err == ''
+        assert capture.out == ''
+
+        assert run_command_mock.call_count == 9
+        args, _ = run_command_mock.call_args_list[-1]
+        assert args[0] == [
+            'docker-compose',
+            '-p', 'grizzly-cli-test-project-suffix-test-user',
+            '-f', '/tmp/static-context/compose.yaml',
+            'config',
+        ]
+
+        assert environ.get('GRIZZLY_RUN_FILE', None) == f'{test_context}/test.feature'
+        assert environ.get('GRIZZLY_MTU', None) == '1800'
+        assert environ.get('GRIZZLY_EXECUTION_CONTEXT', None) == '/tmp/execution-context'
+        assert environ.get('GRIZZLY_STATIC_CONTEXT', None) == '/tmp/static-context'
+        assert environ.get('GRIZZLY_MOUNT_CONTEXT', None) == '/tmp/mount-context'
+        assert environ.get('GRIZZLY_PROJECT_NAME', None) == 'grizzly-cli-test-project'
+        assert environ.get('GRIZZLY_USER_TAG', None) == 'test-user'
+        assert environ.get('GRIZZLY_EXPECTED_WORKERS', None) == '1'
+        assert environ.get('GRIZZLY_MASTER_RUN_ARGS', None) == '--foo bar --master'
+        assert environ.get('GRIZZLY_WORKER_RUN_ARGS', None) == '--bar foo --worker'
+        assert environ.get('GRIZZLY_COMMON_RUN_ARGS', None) == '--common true'
+        assert environ.get('GRIZZLY_ENVIRONMENT_FILE', '').startswith(gettempdir())
+        assert environ.get('GRIZZLY_LIMIT_NOFILE', None) == '20000'
+        assert environ.get('GRIZZLY_HEALTH_CHECK_INTERVAL', None) == '10'
+        assert environ.get('GRIZZLY_HEALTH_CHECK_TIMEOUT', None) == '8'
+        assert environ.get('GRIZZLY_HEALTH_CHECK_RETRIES', None) == '30'
+
+    finally:
+        rmtree(test_context, onerror=onerror)
+        for key in environ.keys():
+            if key.startswith('GRIZZLY_'):
+                del environ[key]

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -1,0 +1,81 @@
+
+from shutil import rmtree
+from os import getcwd, environ
+from argparse import ArgumentParser, Namespace
+
+import pytest
+
+from _pytest.tmpdir import TempPathFactory
+from pytest_mock import MockerFixture
+
+from grizzly_cli.local import create_parser, local_run, local
+
+from .helpers import onerror
+
+CWD = getcwd()
+
+
+def test_local(mocker: MockerFixture) -> None:
+    run_mocked = mocker.patch('grizzly_cli.local.run', return_value=0)
+
+    arguments = Namespace(subcommand='run')
+
+    assert local(arguments) == 0
+    assert run_mocked.call_count == 1
+    args, _ = run_mocked.call_args_list[0]
+    assert args[0] is arguments
+    assert args[1] is local_run
+
+    arguments = Namespace(subcommand='foo')
+    with pytest.raises(ValueError) as ve:
+        local(arguments)
+    assert 'unknown subcommand foo' == str(ve.value)
+
+
+def test_local_run(mocker: MockerFixture, tmp_path_factory: TempPathFactory) -> None:
+    run_command = mocker.patch('grizzly_cli.local.run_command', side_effect=[0])
+    test_context = tmp_path_factory.mktemp('test_context')
+    (test_context / 'test.feature').write_text('Feature:')
+
+    parser = ArgumentParser()
+
+    sub_parsers = parser.add_subparsers(dest='test')
+
+    create_parser(sub_parsers)
+
+    try:
+        assert environ.get('GRIZZLY_TEST_VAR', None) is None
+
+        arguments = parser.parse_args([
+            'local', 'run', f'{test_context}/test.feature',
+        ])
+
+        assert local_run(
+            arguments,
+            {
+                'GRIZZLY_TEST_VAR': 'True',
+            },
+            {
+                'master': ['--foo', 'bar', '--master'],
+                'worker': ['--bar', 'foo', '--worker'],
+                'common': ['--common', 'true'],
+            },
+        ) == 0
+
+        assert run_command.call_count == 1
+        args, _ = run_command.call_args_list[-1]
+        assert args[0] == [
+            'behave',
+            f'{test_context}/test.feature',
+            '--foo', 'bar', '--master',
+            '--bar', 'foo', '--worker',
+            '--common', 'true',
+        ]
+
+        assert environ.get('GRIZZLY_TEST_VAR', None) == 'True'
+    finally:
+        rmtree(test_context, onerror=onerror)
+        try:
+            del environ['GRIZZLY_TEST_VAR']
+        except:
+            pass

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,316 +1,16 @@
 from shutil import rmtree
-from os import getcwd, environ, path
-from tempfile import gettempdir
+from os import getcwd, path
 from argparse import ArgumentParser
 
 from _pytest.capture import CaptureFixture
 from _pytest.tmpdir import TempPathFactory
 from pytest_mock import MockerFixture
 
-from grizzly_cli.run import distributed, local, run, create_parser
+from grizzly_cli.run import run, create_parser
 
 from .helpers import onerror
 
 CWD = getcwd()
-
-
-def test_distributed(capsys: CaptureFixture, mocker: MockerFixture, tmp_path_factory: TempPathFactory) -> None:
-    test_context = tmp_path_factory.mktemp('test_context')
-    (test_context / 'test.feature').write_text('Feature:')
-
-    mocker.patch('grizzly_cli.run.getuser', side_effect=['test-user'] * 5)
-    mocker.patch('grizzly_cli.run.get_default_mtu', side_effect=['1500', None, '1400', '1330', '1800'])
-    mocker.patch('grizzly_cli.run.build', side_effect=[255, 0, 0])
-    mocker.patch('grizzly_cli.run.list_images', side_effect=[{}, {}, {}, {'grizzly-cli-test-project': {'test-user': {}}}, {'grizzly-cli-test-project': {'test-user': {}}}])
-
-    import grizzly_cli.run
-    mocker.patch.object(grizzly_cli.run, 'EXECUTION_CONTEXT', '/tmp/execution-context')
-    mocker.patch.object(grizzly_cli.run, 'STATIC_CONTEXT', '/tmp/static-context')
-    mocker.patch.object(grizzly_cli.run, 'MOUNT_CONTEXT', '/tmp/mount-context')
-    mocker.patch.object(grizzly_cli.run, 'PROJECT_NAME', 'grizzly-cli-test-project')
-
-    mocker.patch('grizzly_cli.run.is_docker_compose_v2', return_value=False)
-
-    run_command_mock = mocker.patch('grizzly_cli.run.run_command', side_effect=[111, 0, 0, 1, 0, 0, 1, 0, 13])
-
-    parser = ArgumentParser()
-
-    sub_parsers = parser.add_subparsers(dest='test')
-
-    create_parser(sub_parsers)
-
-    try:
-        arguments = parser.parse_args(['run', 'dist', f'{test_context}/test.feature', '--workers', '3', '--tty'])
-        setattr(arguments, 'container_system', 'docker')
-
-        # this is set in the devcontainer
-        for key in environ.keys():
-            if key.startswith('GRIZZLY_'):
-                del environ[key]
-
-        assert distributed(arguments, {}, {}) == 111
-        capture = capsys.readouterr()
-        import sys
-        assert capture.err == ''
-        assert capture.out == (
-            '!! something in the compose project is not valid, check with:\n'
-            f'grizzly-cli {" ".join(sys.argv[1:])} --validate-config\n'
-        )
-
-        try:
-            del environ['GRIZZLY_MTU']
-        except KeyError:
-            pass
-
-        assert distributed(arguments, {}, {}) == 255
-        capture = capsys.readouterr()
-        assert capture.err == ''
-        assert capture.out == (
-            '!! unable to determine MTU, try manually setting GRIZZLY_MTU environment variable if anything other than 1500 is needed\n'
-            '!! failed to build grizzly-cli-test-project, rc=255\n'
-        )
-        assert environ.get('GRIZZLY_MTU', None) == '1500'
-        assert environ.get('GRIZZLY_EXECUTION_CONTEXT', None) == '/tmp/execution-context'
-        assert environ.get('GRIZZLY_STATIC_CONTEXT', None) == '/tmp/static-context'
-        assert environ.get('GRIZZLY_MOUNT_CONTEXT', None) == '/tmp/mount-context'
-        assert environ.get('GRIZZLY_PROJECT_NAME', None) == 'grizzly-cli-test-project'
-        assert environ.get('GRIZZLY_USER_TAG', None) == 'test-user'
-        assert environ.get('GRIZZLY_EXPECTED_WORKERS', None) == '3'
-        assert environ.get('GRIZZLY_MASTER_RUN_ARGS', None) is None
-        assert environ.get('GRIZZLY_WORKER_RUN_ARGS', None) is None
-        assert environ.get('GRIZZLY_COMMON_RUN_ARGS', None) is None
-        assert environ.get('GRIZZLY_IMAGE_REGISTRY', None) == ''
-        assert environ.get('GRIZZLY_ENVIRONMENT_FILE', '').startswith(gettempdir())
-        assert environ.get('GRIZZLY_LIMIT_NOFILE', None) == '10001'
-        assert environ.get('GRIZZLY_HEALTH_CHECK_INTERVAL', None) == '5'
-        assert environ.get('GRIZZLY_HEALTH_CHECK_TIMEOUT', None) == '3'
-        assert environ.get('GRIZZLY_HEALTH_CHECK_RETRIES', None) == '3'
-        assert environ.get('GRIZZLY_CONTAINER_TTY', None) == 'true'
-
-        # this is set in the devcontainer
-        for key in environ.keys():
-            if key.startswith('GRIZZLY_'):
-                del environ[key]
-
-        arguments = parser.parse_args([
-            'run', 'dist', f'{test_context}/test.feature',
-            '--workers', '3',
-            '--build',
-            '--limit-nofile', '133700',
-            '--health-interval', '10',
-            '--health-timeout', '8',
-            '--health-retries', '30',
-            '--registry', 'gchr.io/biometria-se',
-        ])
-        setattr(arguments, 'container_system', 'docker')
-
-        mocker.patch('grizzly_cli.run.is_docker_compose_v2', side_effect=[True, False])
-
-        # docker-compose v2
-        assert distributed(
-            arguments,
-            {
-                'GRIZZLY_CONFIGURATION_FILE': '/tmp/execution-context/configuration.yaml',
-                'GRIZZLY_TEST_VAR': 'True',
-            },
-            {
-                'master': ['--foo', 'bar', '--master'],
-                'worker': ['--bar', 'foo', '--worker'],
-                'common': ['--common', 'true'],
-            },
-        ) == 1
-        capture = capsys.readouterr()
-        assert capture.err == ''
-        assert capture.out == (
-            '\n!! something went wrong, check container logs with:\n'
-            'docker container logs grizzly-cli-test-project-test-user-master-1\n'
-            'docker container logs grizzly-cli-test-project-test-user-worker-2\n'
-            'docker container logs grizzly-cli-test-project-test-user-worker-3\n'
-            'docker container logs grizzly-cli-test-project-test-user-worker-4\n'
-        )
-
-        assert run_command_mock.call_count == 5
-        args, _ = run_command_mock.call_args_list[-3]
-        assert args[0] == [
-            'docker-compose',
-            '-p', 'grizzly-cli-test-project-test-user',
-            '-f', '/tmp/static-context/compose.yaml',
-            'config',
-        ]
-        args, _ = run_command_mock.call_args_list[-2]
-        assert args[0] == [
-            'docker-compose',
-            '-p', 'grizzly-cli-test-project-test-user',
-            '-f', '/tmp/static-context/compose.yaml',
-            'up',
-            '--scale', 'worker=3',
-            '--remove-orphans',
-        ]
-        args, _ = run_command_mock.call_args_list[-1]
-        assert args[0] == [
-            'docker-compose',
-            '-p', 'grizzly-cli-test-project-test-user',
-            '-f', '/tmp/static-context/compose.yaml',
-            'stop',
-        ]
-
-        assert environ.get('GRIZZLY_RUN_FILE', None) == f'{test_context}/test.feature'
-        assert environ.get('GRIZZLY_MTU', None) == '1400'
-        assert environ.get('GRIZZLY_EXECUTION_CONTEXT', None) == '/tmp/execution-context'
-        assert environ.get('GRIZZLY_STATIC_CONTEXT', None) == '/tmp/static-context'
-        assert environ.get('GRIZZLY_MOUNT_CONTEXT', None) == '/tmp/mount-context'
-        assert environ.get('GRIZZLY_PROJECT_NAME', None) == 'grizzly-cli-test-project'
-        assert environ.get('GRIZZLY_USER_TAG', None) == 'test-user'
-        assert environ.get('GRIZZLY_EXPECTED_WORKERS', None) == '3'
-        assert environ.get('GRIZZLY_MASTER_RUN_ARGS', None) == '--foo bar --master'
-        assert environ.get('GRIZZLY_WORKER_RUN_ARGS', None) == '--bar foo --worker'
-        assert environ.get('GRIZZLY_COMMON_RUN_ARGS', None) == '--common true'
-        assert environ.get('GRIZZLY_ENVIRONMENT_FILE', '').startswith(gettempdir())
-        assert environ.get('GRIZZLY_LIMIT_NOFILE', None) == '133700'
-        assert environ.get('GRIZZLY_HEALTH_CHECK_INTERVAL', None) == '10'
-        assert environ.get('GRIZZLY_HEALTH_CHECK_TIMEOUT', None) == '8'
-        assert environ.get('GRIZZLY_HEALTH_CHECK_RETRIES', None) == '30'
-        assert environ.get('GRIZZLY_IMAGE_REGISTRY', None) == 'gchr.io/biometria-se'
-        assert environ.get('GRIZZLY_CONTAINER_TTY', None) == 'false'
-
-        # docker-compose v1
-        assert distributed(
-            arguments,
-            {
-                'GRIZZLY_CONFIGURATION_FILE': '/tmp/execution-context/configuration.yaml',
-                'GRIZZLY_TEST_VAR': 'True',
-            },
-            {
-                'master': ['--foo', 'bar', '--master'],
-                'worker': ['--bar', 'foo', '--worker'],
-                'common': ['--common', 'true'],
-            },
-        ) == 1
-        capture = capsys.readouterr()
-        assert capture.err == ''
-        assert capture.out == (
-            '\n!! something went wrong, check container logs with:\n'
-            'docker container logs grizzly-cli-test-project-test-user_master_1\n'
-            'docker container logs grizzly-cli-test-project-test-user_worker_1\n'
-            'docker container logs grizzly-cli-test-project-test-user_worker_2\n'
-            'docker container logs grizzly-cli-test-project-test-user_worker_3\n'
-        )
-
-        mocker.patch('grizzly_cli.run.is_docker_compose_v2', return_value=False)
-
-        # this is set in the devcontainer
-        for key in environ.keys():
-            if key.startswith('GRIZZLY_'):
-                del environ[key]
-
-        arguments = parser.parse_args([
-            'run', 'dist', f'{test_context}/test.feature',
-            '--workers', '1',
-            '--id', 'suffix',
-            '--validate-config',
-            '--limit-nofile', '20000',
-            '--health-interval', '10',
-            '--health-timeout', '8',
-            '--health-retries', '30',
-        ])
-        setattr(arguments, 'container_system', 'docker')
-
-        assert distributed(
-            arguments,
-            {
-                'GRIZZLY_CONFIGURATION_FILE': '/tmp/execution-context/configuration.yaml',
-                'GRIZZLY_TEST_VAR': 'True',
-            },
-            {
-                'master': ['--foo', 'bar', '--master'],
-                'worker': ['--bar', 'foo', '--worker'],
-                'common': ['--common', 'true'],
-            },
-        ) == 13
-        capture = capsys.readouterr()
-        assert capture.err == ''
-        assert capture.out == ''
-
-        assert run_command_mock.call_count == 9
-        args, _ = run_command_mock.call_args_list[-1]
-        assert args[0] == [
-            'docker-compose',
-            '-p', 'grizzly-cli-test-project-suffix-test-user',
-            '-f', '/tmp/static-context/compose.yaml',
-            'config',
-        ]
-
-        assert environ.get('GRIZZLY_RUN_FILE', None) == f'{test_context}/test.feature'
-        assert environ.get('GRIZZLY_MTU', None) == '1800'
-        assert environ.get('GRIZZLY_EXECUTION_CONTEXT', None) == '/tmp/execution-context'
-        assert environ.get('GRIZZLY_STATIC_CONTEXT', None) == '/tmp/static-context'
-        assert environ.get('GRIZZLY_MOUNT_CONTEXT', None) == '/tmp/mount-context'
-        assert environ.get('GRIZZLY_PROJECT_NAME', None) == 'grizzly-cli-test-project'
-        assert environ.get('GRIZZLY_USER_TAG', None) == 'test-user'
-        assert environ.get('GRIZZLY_EXPECTED_WORKERS', None) == '1'
-        assert environ.get('GRIZZLY_MASTER_RUN_ARGS', None) == '--foo bar --master'
-        assert environ.get('GRIZZLY_WORKER_RUN_ARGS', None) == '--bar foo --worker'
-        assert environ.get('GRIZZLY_COMMON_RUN_ARGS', None) == '--common true'
-        assert environ.get('GRIZZLY_ENVIRONMENT_FILE', '').startswith(gettempdir())
-        assert environ.get('GRIZZLY_LIMIT_NOFILE', None) == '20000'
-        assert environ.get('GRIZZLY_HEALTH_CHECK_INTERVAL', None) == '10'
-        assert environ.get('GRIZZLY_HEALTH_CHECK_TIMEOUT', None) == '8'
-        assert environ.get('GRIZZLY_HEALTH_CHECK_RETRIES', None) == '30'
-
-    finally:
-        rmtree(test_context, onerror=onerror)
-        for key in environ.keys():
-            if key.startswith('GRIZZLY_'):
-                del environ[key]
-
-
-def test_local(mocker: MockerFixture, tmp_path_factory: TempPathFactory) -> None:
-    run_command = mocker.patch('grizzly_cli.run.run_command', side_effect=[0])
-    test_context = tmp_path_factory.mktemp('test_context')
-    (test_context / 'test.feature').write_text('Feature:')
-
-    parser = ArgumentParser()
-
-    sub_parsers = parser.add_subparsers(dest='test')
-
-    create_parser(sub_parsers)
-
-    try:
-        assert environ.get('GRIZZLY_TEST_VAR', None) is None
-
-        arguments = parser.parse_args([
-            'run', 'local', f'{test_context}/test.feature',
-        ])
-
-        assert local(
-            arguments,
-            {
-                'GRIZZLY_TEST_VAR': 'True',
-            },
-            {
-                'master': ['--foo', 'bar', '--master'],
-                'worker': ['--bar', 'foo', '--worker'],
-                'common': ['--common', 'true'],
-            },
-        ) == 0
-
-        assert run_command.call_count == 1
-        args, _ = run_command.call_args_list[-1]
-        assert args[0] == [
-            'behave',
-            f'{test_context}/test.feature',
-            '--foo', 'bar', '--master',
-            '--bar', 'foo', '--worker',
-            '--common', 'true',
-        ]
-
-        assert environ.get('GRIZZLY_TEST_VAR', None) == 'True'
-    finally:
-        rmtree(test_context, onerror=onerror)
-        try:
-            del environ['GRIZZLY_TEST_VAR']
-        except:
-            pass
 
 
 def test_run(capsys: CaptureFixture, mocker: MockerFixture, tmp_path_factory: TempPathFactory) -> None:
@@ -326,7 +26,7 @@ def test_run(capsys: CaptureFixture, mocker: MockerFixture, tmp_path_factory: Te
 
     sub_parsers = parser.add_subparsers(dest='test')
 
-    create_parser(sub_parsers)
+    create_parser(sub_parsers, parent='local')
 
     try:
         mocker.patch('grizzly_cli.run.EXECUTION_CONTEXT', str(execution_context))
@@ -335,19 +35,20 @@ def test_run(capsys: CaptureFixture, mocker: MockerFixture, tmp_path_factory: Te
         mocker.patch('grizzly_cli.run.find_variable_names_in_questions', side_effect=[['foo', 'bar'], []])
         mocker.patch('grizzly_cli.run.distribution_of_users_per_scenario', autospec=True)
         ask_yes_no_mock = mocker.patch('grizzly_cli.run.ask_yes_no', autospec=True)
-        distributed_mock = mocker.patch('grizzly_cli.run.distributed', side_effect=[0])
-        local_mock = mocker.patch('grizzly_cli.run.local', side_effect=[0])
+        distributed_mock = mocker.MagicMock(return_value=0)
+        local_mock = mocker.MagicMock(return_value=0)
         get_input_mock = mocker.patch('grizzly_cli.run.get_input', side_effect=['bar', 'foo'])
 
         setattr(getattr(run, '__wrapped__'), '__value__', str(execution_context))
 
         arguments = parser.parse_args([
-            'run', '-e', f'{execution_context}/configuration.yaml',
-            'dist', f'{execution_context}/test.feature',
+            'run',
+            '-e', f'{execution_context}/configuration.yaml',
+            f'{execution_context}/test.feature',
         ])
         setattr(arguments, 'verbose', True)
 
-        assert run(arguments) == 0
+        assert run(arguments, distributed_mock) == 0
 
         capture = capsys.readouterr()
         assert capture.err == ''
@@ -400,11 +101,12 @@ bar = foo
         )
 
         arguments = parser.parse_args([
-            'run', '-e', f'{execution_context}/configuration.yaml',
-            'local', f'{execution_context}/test.feature',
+            'run',
+            '-e', f'{execution_context}/configuration.yaml',
+            f'{execution_context}/test.feature',
         ])
 
-        assert run(arguments) == 0
+        assert run(arguments, local_mock) == 0
 
         capture = capsys.readouterr()
 


### PR DESCRIPTION
implementation for Biometria-se/grizzly#83.

run {local,dist}, init, build is now local {run}, dist {run,build} and init.