### PR TITLE
Change scenario hash to numerical index (issue#71)

### DIFF
--- a/grizzly_cli/utils.py
+++ b/grizzly_cli/utils.py
@@ -7,7 +7,6 @@ from os import path, environ
 from shutil import which, rmtree
 from behave.parser import parse_file as feature_file_parser
 from argparse import Namespace as Arguments
-from operator import attrgetter
 from json import loads as jsonloads
 from functools import wraps
 from packaging import version as versioning
@@ -511,11 +510,11 @@ def distribution_of_users_per_scenario(args: Arguments, environ: Dict[str, Any])
 
     scenario_user_count = 0
 
-    for index, scenario in enumerate(sorted(list(grizzly_cli.SCENARIOS), key=attrgetter('name'))):
+    for index, scenario in enumerate(grizzly_cli.SCENARIOS):
         if len(scenario.steps) < 1:
             raise ValueError(f'{scenario.name} does not have any steps')
 
-        _pre_populate_scenario(scenario, index=index+1)
+        _pre_populate_scenario(scenario, index=index + 1)
 
         if index == 0:  # background_steps is only processed for first scenario in grizzly
             for step in scenario.background_steps or []:

--- a/grizzly_cli/utils.py
+++ b/grizzly_cli/utils.py
@@ -8,7 +8,6 @@ from shutil import which, rmtree
 from behave.parser import parse_file as feature_file_parser
 from argparse import Namespace as Arguments
 from operator import attrgetter
-from hashlib import sha1 as sha1_hash
 from json import loads as jsonloads
 from functools import wraps
 from packaging import version as versioning
@@ -463,9 +462,9 @@ def distribution_of_users_per_scenario(args: Arguments, environ: Dict[str, Any])
 
     class ScenarioProperties:
         name: str
+        index: int
         identifier: str
         user: Optional[str]
-        symbol: str
         weight: float
         iterations: int
         user_count: int
@@ -473,18 +472,18 @@ def distribution_of_users_per_scenario(args: Arguments, environ: Dict[str, Any])
         def __init__(
             self,
             name: str,
-            symbol: str,
+            index: int,
             weight: Optional[float] = None,
             user: Optional[str] = None,
             iterations: Optional[int] = None,
             user_count: Optional[int] = None,
         ) -> None:
             self.name = name
-            self.symbol = symbol
+            self.index = index
             self.user = user
             self.iterations = iterations or 1
             self.weight = weight or 1.0
-            self.identifier = generate_identifier(name)
+            self.identifier = f'{index:03}'
             self.user_count = user_count or 0
 
         def __str__(self) -> str:
@@ -499,22 +498,16 @@ def distribution_of_users_per_scenario(args: Arguments, environ: Dict[str, Any])
 
     distribution: Dict[str, ScenarioProperties] = {}
     variables = {key.replace('TESTDATA_VARIABLE_', ''): _guess_datatype(value) for key, value in environ.items() if key.startswith('TESTDATA_VARIABLE_')}
-    current_symbol = 65  # ASCII decimal for A
 
-    def _pre_populate_scenario(scenario: Scenario) -> None:
-        nonlocal current_symbol
+    def _pre_populate_scenario(scenario: Scenario, index: int) -> None:
         if scenario.name not in distribution:
             distribution[scenario.name] = ScenarioProperties(
                 name=scenario.name,
+                index=index,
                 user=None,
-                symbol=chr(current_symbol),
                 weight=None,
                 iterations=None,
             )
-            current_symbol += 1
-
-    def generate_identifier(name: str) -> str:
-        return sha1_hash(name.encode('utf-8')).hexdigest()[:8]
 
     scenario_user_count = 0
 
@@ -522,7 +515,7 @@ def distribution_of_users_per_scenario(args: Arguments, environ: Dict[str, Any])
         if len(scenario.steps) < 1:
             raise ValueError(f'{scenario.name} does not have any steps')
 
-        _pre_populate_scenario(scenario)
+        _pre_populate_scenario(scenario, index=index+1)
 
         if index == 0:  # background_steps is only processed for first scenario in grizzly
             for step in scenario.background_steps or []:
@@ -578,9 +571,7 @@ def distribution_of_users_per_scenario(args: Arguments, environ: Dict[str, Any])
             raise ValueError(f'{scenario.name} will have {scenario.user_count} users to run {scenario.iterations} iterations, increase iterations or lower user count')
 
     def print_table_lines(max_length_iterations: int, max_length_users: int, max_length_description: int) -> None:
-        sys.stdout.write('-' * 10)
-        sys.stdout.write('-|-')
-        sys.stdout.write('-' * 6)
+        sys.stdout.write('-' * 5)
         sys.stdout.write('-|-')
         sys.stdout.write('-' * 6)
         sys.stdout.write('|-')
@@ -604,9 +595,8 @@ def distribution_of_users_per_scenario(args: Arguments, environ: Dict[str, Any])
         max_length_users = max(len(str(scenario.user_count)), max_length_users)
 
     for scenario in distribution.values():
-        row = '{:10}   {:^6}   {:>6.1f}  {:>{}}  {:>{}}  {}'.format(
+        row = '{:5}   {:>6.1f}  {:>{}}  {:>{}}  {}'.format(
             scenario.identifier,
-            scenario.symbol,
             scenario.weight,
             scenario.iterations,
             max_length_iterations,
@@ -617,9 +607,8 @@ def distribution_of_users_per_scenario(args: Arguments, environ: Dict[str, Any])
         rows.append(row)
 
     print('each scenario will execute accordingly:\n')
-    print('{:10}   {:6}   {:>6}  {:>{}}  {:>{}}  {}'.format(
-        'identifier',
-        'symbol',
+    print('{:5}   {:>6}  {:>{}}  {:>{}}  {}'.format(
+        'ident',
         'weight',
         '#iter', max_length_iterations,
         '#user', max_length_users,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -408,11 +408,11 @@ def test_distribution_of_users_per_scenario(capsys: CaptureFixture, mocker: Mock
 
         each scenario will execute accordingly:
 
-        identifier   symbol   weight  #iter  #user  description
-        -----------|--------|-------|------|------|-------------|
-        02ce541f       A         1.0      1      1  scenario-1
-        91d624d8       B         1.0      1      1  scenario-2
-        -----------|--------|-------|------|------|-------------|
+        ident   weight  #iter  #user  description
+        ------|-------|------|------|-------------|
+        001        1.0      1      1  scenario-1
+        002        1.0      1      1  scenario-2
+        ------|-------|------|------|-------------|
 
     ''')
     capsys.readouterr()
@@ -493,11 +493,11 @@ def test_distribution_of_users_per_scenario(capsys: CaptureFixture, mocker: Mock
 
         each scenario will execute accordingly:
 
-        identifier   symbol   weight  #iter  #user  description
-        -----------|--------|-------|------|------|-------------|
-        02ce541f       A        10.0     50     36  scenario-1
-        91d624d8       B         1.0      5      4  scenario-2
-        -----------|--------|-------|------|------|-------------|
+        ident   weight  #iter  #user  description
+        ------|-------|------|------|-------------|
+        001       10.0     50     36  scenario-1
+        002        1.0      5      4  scenario-2
+        ------|-------|------|------|-------------|
 
     ''')
     capsys.readouterr()
@@ -561,12 +561,12 @@ def test_distribution_of_users_per_scenario(capsys: CaptureFixture, mocker: Mock
 
         each scenario will execute accordingly:
 
-        identifier   symbol   weight  #iter  #user  description
-        -----------|--------|-------|------|------|--------------------------------------------------------------------------------------|
-        5b66789b       A       100.0    500     46  scenario-1 testing a lot of stuff
-        d06b7314       B        50.0    750     23  scenario-2 testing a lot more of many different things that scenario-1 does not test
-        4a0fab3b       C         1.0     10      1  scenario-3
-        -----------|--------|-------|------|------|--------------------------------------------------------------------------------------|
+        ident   weight  #iter  #user  description
+        ------|-------|------|------|--------------------------------------------------------------------------------------|
+        001      100.0    500     46  scenario-1 testing a lot of stuff
+        002       50.0    750     23  scenario-2 testing a lot more of many different things that scenario-1 does not test
+        003        1.0     10      1  scenario-3
+        ------|-------|------|------|--------------------------------------------------------------------------------------|
 
     ''')
     capsys.readouterr()
@@ -659,15 +659,15 @@ def test_distribution_of_users_per_scenario(capsys: CaptureFixture, mocker: Mock
 
         each scenario will execute accordingly:
 
-        identifier   symbol   weight  #iter  #user  description
-        -----------|--------|-------|------|------|-------------|
-        02ce541f       A        25.0      2      1  scenario-1
-        91d624d8       B        42.0      4      1  scenario-2
-        4a0fab3b       C         8.0      1      1  scenario-3
-        62fc25f5       D        13.0      1      1  scenario-4
-        367a6eff       E         6.0      1      1  scenario-5
-        7d326458       F         6.0      1      1  scenario-6
-        -----------|--------|-------|------|------|-------------|
+        ident   weight  #iter  #user  description
+        ------|-------|------|------|-------------|
+        001       25.0      2      1  scenario-1
+        002       42.0      4      1  scenario-2
+        003        8.0      1      1  scenario-3
+        004       13.0      1      1  scenario-4
+        005        6.0      1      1  scenario-5
+        006        6.0      1      1  scenario-6
+        ------|-------|------|------|-------------|
 
     ''')
     capsys.readouterr()
@@ -695,10 +695,10 @@ def test_distribution_of_users_per_scenario(capsys: CaptureFixture, mocker: Mock
 
         each scenario will execute accordingly:
 
-        identifier   symbol   weight  #iter  #user  description
-        -----------|--------|-------|------|------|-------------|
-        02ce541f       A        25.0      1      1  scenario-1
-        -----------|--------|-------|------|------|-------------|
+        ident   weight  #iter  #user  description
+        ------|-------|------|------|-------------|
+        001       25.0      1      1  scenario-1
+        ------|-------|------|------|-------------|
 
     ''')
     capsys.readouterr()


### PR DESCRIPTION
grizzly-cli adaptation for implementation of Biometria-se/grizzly#71.

use numerical index based on the order the scenarios are defined in the feature file, instead of sha1 hash of textual name of scenario.

removed "symbol", since it is not used since removing the timeline of user spawning.