### PR TITLE
subcommand is not set for command `init`

### DIFF
--- a/grizzly_cli/__main__.py
+++ b/grizzly_cli/__main__.py
@@ -93,6 +93,8 @@ def _parse_arguments() -> argparse.Namespace:
 
         if args.registry is not None and not args.registry.endswith('/'):
             setattr(args, 'registry', f'{args.registry}/')
+    elif args.command == 'init':
+        setattr(args, 'subcommand', None)
 
     if args.subcommand == 'run':
         if args.command == 'dist':

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -402,6 +402,11 @@ def test__parse_argument(capsys: CaptureFixture, mocker: MockerFixture, tmp_path
         assert not arguments.build
         assert arguments.registry == 'gchr.io/biometria-se/'
 
+        sys.argv = ['grizzly-cli', 'init', 'test-project']
+        arguments = _parse_arguments()
+
+        assert arguments.project == 'test-project'
+        assert getattr(arguments, 'subcommand', None) is None
     finally:
         chdir(CWD)
         rmtree(test_context_root, onerror=onerror)


### PR DESCRIPTION
make sure that Namespace attribute `subcommand` at least exists.

```bash
$ grizzly-cli init test
Traceback (most recent call last):
  File "/home/vscode/.local/bin/grizzly-cli", line 8, in <module>
    sys.exit(main())
  File "/home/vscode/.local/lib/python3.10/site-packages/grizzly_cli/__main__.py", line 122, in main
    args = _parse_arguments()
  File "/home/vscode/.local/lib/python3.10/site-packages/grizzly_cli/__main__.py", line 97, in _parse_arguments
    if args.subcommand == 'run':
AttributeError: 'Namespace' object has no attribute 'subcommand'. Did you mean: 'command'?
```