### PR TITLE
wait for workers report after rampup and inject arguments via metadata comments

### DIFF
--- a/grizzly_cli/distributed/__init__.py
+++ b/grizzly_cli/distributed/__init__.py
@@ -88,6 +88,16 @@ def create_parser(sub_parser: ArgumentSubParser) -> None:
         required=False,
         help='start containers with a TTY enabled',
     )
+    dist_parser.add_argument(
+        '--wait-for-worker',
+        type=str,
+        default=None,
+        required=False,
+        help=(
+            'sets enviroment variable LOCUST_WAIT_FOR_WORKERS_REPORT_AFTER_RAMP_UP, which tells master to wait '
+            'this amount of time for worker report'
+        )
+    )
 
     group_build = dist_parser.add_mutually_exclusive_group()
     group_build.add_argument(
@@ -140,6 +150,9 @@ def distributed_run(args: Arguments, environ: Dict[str, Any], run_arguments: Dic
     if args.file is not None:
         os.environ['GRIZZLY_RUN_FILE'] = args.file
 
+    if args.wait_for_worker is not None:
+        os.environ['LOCUST_WAIT_FOR_WORKERS_REPORT_AFTER_RAMP_UP'] = f'{args.wait_for_worker}'
+
     mtu = get_default_mtu(args)
 
     if mtu is None and os.environ.get('GRIZZLY_MTU', None) is None:
@@ -189,6 +202,9 @@ def distributed_run(args: Arguments, environ: Dict[str, Any], run_arguments: Dic
         fd.write(f'COLUMNS={columns}\n'.encode('utf-8'))
         fd.write(f'LINES={lines}\n'.encode('utf-8'))
         fd.write(f'GRIZZLY_CONTAINER_TTY={os.environ["GRIZZLY_CONTAINER_TTY"]}\n'.encode('utf-8'))
+
+        if args.wait_for_worker is not None:
+            fd.write(f'LOCUST_WAIT_FOR_WORKERS_REPORT_AFTER_RAMP_UP="{args.wait_for_worker}"'.encode('utf-8'))
 
         fd.flush()
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ install_requires =
     Jinja2 >=3.0.3,<4.0.0
     requests >=2.27.1,<3.0.0
     packaging >=21.3,<22.0
+    chardet >=3.0.2,<5.0.0
 
 [options.entry_points]
 console_scripts =

--- a/tests/argparse/bashcompletion/test__init__.py
+++ b/tests/argparse/bashcompletion/test__init__.py
@@ -385,11 +385,17 @@ class TestBashCompleteAction:
             ),
             (
                 'grizzly-cli dist -',
-                '-h --help --workers --id --limit-nofile --health-retries --health-timeout --health-interval --registry --tty --wait-for-worker --force-build --build --validate-config',
+                (
+                    '-h --help --workers --id --limit-nofile --health-retries --health-timeout --health-interval --registry '
+                    '--tty --wait-for-worker --force-build --build --validate-config'
+                ),
             ),
             (
                 'grizzly-cli dist --',
-                '--help --workers --id --limit-nofile --health-retries --health-timeout --health-interval --registry --tty --wait-for-worker --force-build --build --validate-config',
+                (
+                    '--help --workers --id --limit-nofile --health-retries --health-timeout --health-interval --registry '
+                    '--tty --wait-for-worker --force-build --build --validate-config'
+                ),
             ),
             (
                 'grizzly-cli dist --workers',
@@ -401,7 +407,10 @@ class TestBashCompleteAction:
             ),
             (
                 'grizzly-cli dist --workers 8',
-                '-h --help --id --limit-nofile --health-retries --health-timeout --health-interval --registry --tty --wait-for-worker --force-build --build --validate-config build run',
+                (
+                    '-h --help --id --limit-nofile --health-retries --health-timeout --health-interval --registry --tty '
+                    '--wait-for-worker --force-build --build --validate-config build run'
+                ),
             ),
             (
                 'grizzly-cli dist --workers 8 --force-build',

--- a/tests/argparse/bashcompletion/test__init__.py
+++ b/tests/argparse/bashcompletion/test__init__.py
@@ -380,16 +380,16 @@ class TestBashCompleteAction:
                 'grizzly-cli dist',
                 (
                     '-h --help --workers --id --limit-nofile --health-retries --health-timeout --health-interval --registry '
-                    '--tty --force-build --build --validate-config build run'
+                    '--tty --wait-for-worker --force-build --build --validate-config build run'
                 )
             ),
             (
                 'grizzly-cli dist -',
-                '-h --help --workers --id --limit-nofile --health-retries --health-timeout --health-interval --registry --tty --force-build --build --validate-config',
+                '-h --help --workers --id --limit-nofile --health-retries --health-timeout --health-interval --registry --tty --wait-for-worker --force-build --build --validate-config',
             ),
             (
                 'grizzly-cli dist --',
-                '--help --workers --id --limit-nofile --health-retries --health-timeout --health-interval --registry --tty --force-build --build --validate-config',
+                '--help --workers --id --limit-nofile --health-retries --health-timeout --health-interval --registry --tty --wait-for-worker --force-build --build --validate-config',
             ),
             (
                 'grizzly-cli dist --workers',
@@ -401,11 +401,11 @@ class TestBashCompleteAction:
             ),
             (
                 'grizzly-cli dist --workers 8',
-                '-h --help --id --limit-nofile --health-retries --health-timeout --health-interval --registry --tty --force-build --build --validate-config build run',
+                '-h --help --id --limit-nofile --health-retries --health-timeout --health-interval --registry --tty --wait-for-worker --force-build --build --validate-config build run',
             ),
             (
                 'grizzly-cli dist --workers 8 --force-build',
-                '-h --help --id --limit-nofile --health-retries --health-timeout --health-interval --registry --tty build run',
+                '-h --help --id --limit-nofile --health-retries --health-timeout --health-interval --registry --tty --wait-for-worker build run',
             ),
         ],
     )

--- a/tests/distributed/test___init__.py
+++ b/tests/distributed/test___init__.py
@@ -116,10 +116,11 @@ def test_distributed_run(capsys: CaptureFixture, mocker: MockerFixture, tmp_path
         assert environ.get('GRIZZLY_HEALTH_CHECK_TIMEOUT', None) == '3'
         assert environ.get('GRIZZLY_HEALTH_CHECK_RETRIES', None) == '3'
         assert environ.get('GRIZZLY_CONTAINER_TTY', None) == 'true'
+        assert environ.get('LOCUST_WAIT_FOR_WORKERS_REPORT_AFTER_RAMP_UP', None) is None
 
         # this is set in the devcontainer
         for key in environ.keys():
-            if key.startswith('GRIZZLY_'):
+            if key.startswith('GRIZZLY_') or key.startswith('LOCUST_'):
                 del environ[key]
 
         arguments = parser.parse_args([
@@ -131,6 +132,7 @@ def test_distributed_run(capsys: CaptureFixture, mocker: MockerFixture, tmp_path
             '--health-timeout', '8',
             '--health-retries', '30',
             '--registry', 'gchr.io/biometria-se',
+            '--wait-for-worker', '10000',
             'run',
             f'{test_context}/test.feature',
         ])
@@ -204,6 +206,7 @@ def test_distributed_run(capsys: CaptureFixture, mocker: MockerFixture, tmp_path
         assert environ.get('GRIZZLY_HEALTH_CHECK_RETRIES', None) == '30'
         assert environ.get('GRIZZLY_IMAGE_REGISTRY', None) == 'gchr.io/biometria-se'
         assert environ.get('GRIZZLY_CONTAINER_TTY', None) == 'false'
+        assert environ.get('LOCUST_WAIT_FOR_WORKERS_REPORT_AFTER_RAMP_UP', None) == '10000'
 
         # docker-compose v1
         assert distributed_run(
@@ -232,7 +235,7 @@ def test_distributed_run(capsys: CaptureFixture, mocker: MockerFixture, tmp_path
 
         # this is set in the devcontainer
         for key in environ.keys():
-            if key.startswith('GRIZZLY_'):
+            if key.startswith('GRIZZLY_') or key.startswith('LOCUST_'):
                 del environ[key]
 
         arguments = parser.parse_args([
@@ -244,6 +247,7 @@ def test_distributed_run(capsys: CaptureFixture, mocker: MockerFixture, tmp_path
             '--health-interval', '10',
             '--health-timeout', '8',
             '--health-retries', '30',
+            '--wait-for-worker', '1.25 * WORKER_REPORT_INTERVAL',
             'run', f'{test_context}/test.feature',
         ])
         setattr(arguments, 'container_system', 'docker')
@@ -289,6 +293,7 @@ def test_distributed_run(capsys: CaptureFixture, mocker: MockerFixture, tmp_path
         assert environ.get('GRIZZLY_HEALTH_CHECK_INTERVAL', None) == '10'
         assert environ.get('GRIZZLY_HEALTH_CHECK_TIMEOUT', None) == '8'
         assert environ.get('GRIZZLY_HEALTH_CHECK_RETRIES', None) == '30'
+        assert environ.get('LOCUST_WAIT_FOR_WORKERS_REPORT_AFTER_RAMP_UP', None) == '1.25 * WORKER_REPORT_INTERVAL'
 
     finally:
         rmtree(test_context, onerror=onerror)

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -1,3 +1,5 @@
+import sys
+
 from hashlib import sha1
 from typing import Dict, Optional, cast
 from argparse import ArgumentParser as CoreArgumentParser, Namespace
@@ -10,7 +12,7 @@ from _pytest.capture import CaptureFixture
 from _pytest.tmpdir import TempPathFactory
 from pytest_mock import MockerFixture
 
-from grizzly_cli.__main__ import _create_parser, _parse_arguments, main
+from grizzly_cli.__main__ import _create_parser, _parse_arguments, _inject_additional_arguments_from_metadata, main
 
 from .helpers import onerror
 
@@ -414,10 +416,88 @@ def test__parse_argument(capsys: CaptureFixture, mocker: MockerFixture, tmp_path
         rmtree(test_context_root, onerror=onerror)
 
 
+def test__inject_additional_arguments_from_metadata(tmp_path_factory: TempPathFactory, capsys: CaptureFixture, mocker: MockerFixture) -> None:
+    test_context = tmp_path_factory.mktemp('test_context')
+
+    test_feature_file = test_context / 'test.feature'
+    test_feature_file.touch()
+    mocker.patch('grizzly_cli.__main__.get_distributed_system', return_value='docker')
+
+    try:
+        chdir(test_context)
+        test_feature_file.write_text('# grizzly-cli run --verbose\nFeature:\n')
+        sys.argv = ['grizzly-cli', 'dist', 'run', 'test.feature']
+
+        orig_args = _parse_arguments()
+        assert not orig_args.verbose
+
+        args = _inject_additional_arguments_from_metadata(orig_args)
+        capture = capsys.readouterr()
+
+        assert capture.err == ''
+        assert capture.out == ''
+        assert args.verbose
+
+        test_feature_file.write_text('# grizzly-cli local --hello\nFeature:\n')
+        sys.argv = ['grizzly-cli', 'dist', 'run', 'test.feature']
+
+        orig_args = _parse_arguments()
+        args = _inject_additional_arguments_from_metadata(orig_args)
+
+        capture = capsys.readouterr()
+        assert capture.err == ''
+        assert capture.out == '?? ignoring local --hello\n'
+
+        test_feature_file.write_text('Feature:\n')
+        sys.argv = ['grizzly-cli', 'dist', 'run', 'test.feature']
+
+        orig_args = _parse_arguments()
+        args = _inject_additional_arguments_from_metadata(orig_args)
+
+        assert args is orig_args
+
+        capture = capsys.readouterr()
+        assert capture.err == ''
+        assert capture.out == ''
+
+        test_feature_file.write_text('# grizzly-cli --health-timeout 100\nFeature:\n')
+        sys.argv = ['grizzly-cli', 'dist', 'run', 'test.feature']
+
+        orig_args = _parse_arguments()
+        args = _inject_additional_arguments_from_metadata(orig_args)
+
+        assert args.health_timeout == orig_args.health_timeout
+
+        capture = capsys.readouterr()
+        assert capture.err == ''
+        assert capture.out == '?? ignoring --health-timeout 100\n'
+
+        test_feature_file.write_text('# grizzly-cli dist --health-timeout 100 --health-retries 101\nFeature:\n# grizzly-cli dist --health-interval 5\n')
+        sys.argv = ['grizzly-cli', 'dist', 'run', 'test.feature']
+
+        orig_args = _parse_arguments()
+        args = _inject_additional_arguments_from_metadata(orig_args)
+
+        assert args.health_timeout == 100
+        assert args.health_retries == 101
+        assert args.health_interval == 5
+
+        capture = capsys.readouterr()
+        assert capture.err == ''
+        assert capture.out == ''
+    finally:
+        chdir(CWD)
+        rmtree(test_context, onerror=onerror)
+
+
 def test_main(mocker: MockerFixture, capsys: CaptureFixture) -> None:
     local_mock = mocker.patch('grizzly_cli.__main__.local', side_effect=[0])
-    dist_mock = mocker.patch('grizzly_cli.__main__.distributed', side_effect=[1337])
+    dist_mock = mocker.patch('grizzly_cli.__main__.distributed', side_effect=[1337, 1373])
     init_mock = mocker.patch('grizzly_cli.__main__.init', side_effect=[7331])
+    inject_additional_arguments_from_metadata_mock = mocker.patch(
+        'grizzly_cli.__main__._inject_additional_arguments_from_metadata',
+        return_value=Namespace(command='dist', file='test.feature'),
+    )
     mocker.patch('grizzly_cli.__main__._parse_arguments', side_effect=[
         Namespace(command='local'),
         Namespace(command='dist'),
@@ -425,22 +505,26 @@ def test_main(mocker: MockerFixture, capsys: CaptureFixture) -> None:
         Namespace(command='foobar'),
         KeyboardInterrupt,
         ValueError('hello there'),
+        Namespace(command='dist', file='test.feature'),
     ],)
 
     assert main() == 0
     assert local_mock.call_count == 1
     assert dist_mock.call_count == 0
     assert init_mock.call_count == 0
+    assert inject_additional_arguments_from_metadata_mock.call_count == 0
 
     assert main() == 1337
     assert local_mock.call_count == 1
     assert dist_mock.call_count == 1
     assert init_mock.call_count == 0
+    assert inject_additional_arguments_from_metadata_mock.call_count == 0
 
     assert main() == 7331
     assert local_mock.call_count == 1
     assert dist_mock.call_count == 1
     assert init_mock.call_count == 1
+    assert inject_additional_arguments_from_metadata_mock.call_count == 0
 
     assert main() == 1
 
@@ -459,3 +543,12 @@ def test_main(mocker: MockerFixture, capsys: CaptureFixture) -> None:
     capture = capsys.readouterr()
     assert capture.err == ''
     assert capture.out == '\nhello there\n\n!! aborted grizzly-cli\n'
+
+    assert main() == 1373
+    capture = capsys.readouterr()
+    print(capture.err)
+    print(capture.out)
+    assert local_mock.call_count == 1
+    assert dist_mock.call_count == 2
+    assert init_mock.call_count == 1
+    assert inject_additional_arguments_from_metadata_mock.call_count == 1

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -78,6 +78,7 @@ def test__create_parser() -> None:
         '--health-interval',
         '--registry',
         '--tty',
+        '--wait-for-worker',
     ])
     assert sorted([action.dest for action in dist_parser._actions if len(action.option_strings) == 0]) == ['subcommand']
     assert len(dist_parser._subparsers._group_actions) == 1


### PR DESCRIPTION
new argument to be able to override locust default wait time (1000 ms) for workers to report to master. if a custom user has some time consuming work to do before spawning, 1 second is not enough and will cause the master to abort the test prematurely.

implementation for injecting `grizzly-cli` arguments via metadata commends in the feature file that is executing, e.g.:

``` gherkin
# grizzly-cli dist --health-timeout 99 --health-retries 10
Feature:
...
```

Given a command that executes this feature file:
```
grizzly-cli dist run feature/test.example -> grizzly-cli dist --health-timeout 99 --health-retries 10 run feature/test.example
grizzly-cli local run feature/test.example -> grizzly-cli local run feature/test.example
```