### PR TITLE
changes for being able to use in E2E tests

### DIFF
--- a/grizzly_cli/distributed/__init__.py
+++ b/grizzly_cli/distributed/__init__.py
@@ -99,6 +99,13 @@ def create_parser(sub_parser: ArgumentSubParser) -> None:
         )
     )
 
+    dist_parser.add_argument(
+        '--image-name',
+        type=str,
+        default=None,
+        help='override image name, which otherwise would be the name of the directory where command is executed in',
+    )
+
     group_build = dist_parser.add_mutually_exclusive_group()
     group_build.add_argument(
         '--force-build',
@@ -161,12 +168,18 @@ def distributed_run(args: Arguments, environ: Dict[str, Any], run_arguments: Dic
 
     columns, lines = get_terminal_size()
 
+    if args.image_name is None:
+        image_name = PROJECT_NAME
+    else:
+        image_name = args.image_name
+
     # set environment variables needed by compose files, when *-compose executes
     os.environ['GRIZZLY_MTU'] = cast(str, mtu)
     os.environ['GRIZZLY_EXECUTION_CONTEXT'] = EXECUTION_CONTEXT
     os.environ['GRIZZLY_STATIC_CONTEXT'] = STATIC_CONTEXT
     os.environ['GRIZZLY_MOUNT_CONTEXT'] = MOUNT_CONTEXT
     os.environ['GRIZZLY_PROJECT_NAME'] = PROJECT_NAME
+    os.environ['GRIZZLY_IMAGE_NAME'] = image_name
     os.environ['GRIZZLY_USER_TAG'] = tag
     os.environ['GRIZZLY_EXPECTED_WORKERS'] = str(args.workers)
     os.environ['GRIZZLY_LIMIT_NOFILE'] = str(args.limit_nofile)

--- a/grizzly_cli/distributed/__init__.py
+++ b/grizzly_cli/distributed/__init__.py
@@ -254,6 +254,7 @@ def distributed_run(args: Arguments, environ: Dict[str, Any], run_arguments: Dic
             'up',
             *compose_scale_argument,
             '--remove-orphans',
+            '--exit-code-from', 'master'
         ]
 
         rc = run_command(compose_command, verbose=args.verbose)

--- a/grizzly_cli/distributed/build.py
+++ b/grizzly_cli/distributed/build.py
@@ -32,13 +32,20 @@ def create_parser(sub_parser: ArgumentSubParser) -> None:
         required=False,
         help='push built image to this registry, if the registry has authentication you need to login first',
     )
-    # used during development, hide from help
+    # <!-- used during development, hide from help
     build_parser.add_argument(
         '--local-install',
         action='store_true',
         default=False,
         help=SUPPRESS,
     )
+    build_parser.add_argument(
+        '--image-name',
+        type=str,
+        default=None,
+        help=SUPPRESS,
+    )
+    # used during development, hide from help -->
 
     if build_parser.prog != 'grizzly-cli dist build':  # pragma: no cover
         build_parser.prog = 'grizzly-cli dist build'
@@ -110,7 +117,10 @@ def _create_build_command(args: Arguments, containerfile: str, tag: str, context
 def build(args: Arguments) -> int:
     tag = getuser()
 
-    image_name = f'{PROJECT_NAME}:{tag}'
+    if args.image_name is None:
+        image_name = f'{PROJECT_NAME}:{tag}'
+    else:
+        image_name = f'{args.image_name}:{tag}'
 
     build_command = _create_build_command(
         args,

--- a/grizzly_cli/distributed/build.py
+++ b/grizzly_cli/distributed/build.py
@@ -111,10 +111,10 @@ def _create_build_command(args: Arguments, containerfile: str, tag: str, context
 def build(args: Arguments) -> int:
     tag = getuser()
 
-    if args.image_name is None:
+    if args.project_name is None:
         image_name = f'{PROJECT_NAME}:{tag}'
     else:
-        image_name = f'{args.image_name}:{tag}'
+        image_name = f'{args.project_name}:{tag}'
 
     build_command = _create_build_command(
         args,

--- a/grizzly_cli/distributed/build.py
+++ b/grizzly_cli/distributed/build.py
@@ -1,7 +1,7 @@
 import os
 
 from typing import List, cast
-from argparse import Namespace as Arguments
+from argparse import SUPPRESS, Namespace as Arguments
 from getpass import getuser
 from socket import gethostbyname, gaierror
 
@@ -32,6 +32,13 @@ def create_parser(sub_parser: ArgumentSubParser) -> None:
         required=False,
         help='push built image to this registry, if the registry has authentication you need to login first',
     )
+    # used during development, hide from help
+    build_parser.add_argument(
+        '--local-install',
+        action='store_true',
+        default=False,
+        help=SUPPRESS,
+    )
 
     if build_parser.prog != 'grizzly-cli dist build':  # pragma: no cover
         build_parser.prog = 'grizzly-cli dist build'
@@ -59,6 +66,11 @@ def _create_build_command(args: Arguments, containerfile: str, tag: str, context
     else:
         grizzly_extra = 'base'
 
+    if args.local_install:
+        install_type = 'local'
+    else:
+        install_type = 'remote'
+
     extra_args: List[str] = []
 
     ibm_mq_lib_host = os.environ.get('IBM_MQ_LIB_HOST', None)
@@ -84,6 +96,7 @@ def _create_build_command(args: Arguments, containerfile: str, tag: str, context
         '--ssh',
         'default',
         '--build-arg', f'GRIZZLY_EXTRA={grizzly_extra}',
+        '--build-arg', f'GRIZZLY_INSTALL_TYPE={install_type}',
         '--build-arg', f'GRIZZLY_UID={getuid()}',
         '--build-arg', f'GRIZZLY_GID={getgid()}',
         *extra_args,
@@ -115,6 +128,8 @@ def build(args: Arguments) -> int:
         build_env['DOCKER_BUILDKIT'] = '1'
 
     rc = run_command(build_command, env=build_env)
+
+    print(f'built image {image_name}')
 
     if getattr(args, 'registry', None) is None or rc != 0:
         return rc

--- a/grizzly_cli/distributed/build.py
+++ b/grizzly_cli/distributed/build.py
@@ -39,12 +39,6 @@ def create_parser(sub_parser: ArgumentSubParser) -> None:
         default=False,
         help=SUPPRESS,
     )
-    build_parser.add_argument(
-        '--image-name',
-        type=str,
-        default=None,
-        help=SUPPRESS,
-    )
     # used during development, hide from help -->
 
     if build_parser.prog != 'grizzly-cli dist build':  # pragma: no cover

--- a/grizzly_cli/static/Containerfile
+++ b/grizzly_cli/static/Containerfile
@@ -1,4 +1,5 @@
 ARG GRIZZLY_EXTRA=base
+ARG GRIZZLY_INSTALL_TYPE=remote
 
 FROM python:3.10-slim as base
 
@@ -33,21 +34,35 @@ RUN cp /tmp/mqm/inc/*.h* /opt/mqm/inc/ \
     && cp /tmp/mqm/msg/en_US/amq.cat /opt/mqm/msg/en_US/
 # mq -->
 
-# <!-- python-base (no extras)
-FROM base as python-base
+# <!-- python-base-no (no extras, no local install)
+FROM base as python-base-remote
 ## NOOP
 # python-base (no extras) -->
 
+# <!-- python-base-yes (no extras, get code from build machine)
+FROM base as python-base-local
+# @TODO: copy whole build context
+COPY . /tmp/grizzly
+# python-local (get code from build machine) -->
+
 # <!-- python-mq (with mq extras -> pymqi)
-FROM python-base as python-mq
+FROM python-base-${GRIZZLY_INSTALL_TYPE} as python-mq
 
 COPY --from=mq /opt/mqm /opt/mqm
 
 ENV LD_LIBRARY_PATH="/opt/mqm/lib64:${LD_LIBRARY_PATH}"
 # python-mq (with mq extras -> pymqi) -->
 
-# <!-- python
-FROM python-${GRIZZLY_EXTRA} AS python
+# <!-- python-mq-yes (with mq extras -> pymqi, local install)
+FROM python-mq as python-mq-local
+# python-mq-yes (with mq extras -> pymqi, local install) -->
+
+# <!-- python-mq-no (with mq extras -> pymqi, remote install)
+FROM python-mq as python-mq-remote
+# python-mq-no (with mq extras -> pymqi, remote install) -->
+
+# <!-- python-venv
+FROM python-${GRIZZLY_EXTRA}-${GRIZZLY_INSTALL_TYPE} AS python-venv
 
 RUN apt-get install -y --no-install-recommends \
     openssh-client \
@@ -69,10 +84,38 @@ RUN python -m venv /venv
 
 ENV PATH="/venv/bin:$PATH"
 
+# python-venv -->
+
+# <!-- python-venv-base-local (no mq extras, local install)
+FROM python-venv as python-venv-base-local
+
+RUN python -m pip --disable-pip-version-check --no-cache-dir install /tmp/grizzly
+# python-venv-base-local (no mq extras, local install) -->
+
+# <!-- python-venv-mq-local (mq extras, local install)
+FROM python-venv as python-venv-mq-local
+
+RUN python -m pip --disable-pip-version-check --no-cache-dir install /tmp/grizzly[mq]
+# python-venv-mq-local (mq extras, local install) -->
+
+# <!-- python-venv-base-remote (no mq extras, remote install)
+FROM python-venv as python-venv-base-remote
+
 COPY requirements.txt /tmp
 
-RUN --mount=type=ssh GIT_SSH_COMMAND='ssh -o StrictHostKeyChecking=no' pip --disable-pip-version-check --no-cache-dir install -r /tmp/requirements.txt
-# python -->
+RUN --mount=type=ssh GIT_SSH_COMMAND='ssh -o StrictHostKeyChecking=no' python -m pip --disable-pip-version-check --no-cache-dir install -r /tmp/requirements.txt
+# python-venv-base-remote (no mq extras, remote install) -->
+
+
+# <!-- python-venv-mq-remote (no mq extras, remote install)
+FROM python-venv-base-remote as python-venv-mq-remote
+# NOOP, same as without mq extras, installed from requirements.txt
+# python-venv-mq-remote (no mq extras, remote install) -->
+
+# <!-- python (simple reference to copy from)
+FROM python-venv-${GRIZZLY_EXTRA}-${GRIZZLY_INSTALL_TYPE} as python
+# NOOP
+# python (simple reference to copy from) -->
 
 # <!-- entrypoint
 FROM base AS entrypoint

--- a/grizzly_cli/static/Containerfile
+++ b/grizzly_cli/static/Containerfile
@@ -34,16 +34,16 @@ RUN cp /tmp/mqm/inc/*.h* /opt/mqm/inc/ \
     && cp /tmp/mqm/msg/en_US/amq.cat /opt/mqm/msg/en_US/
 # mq -->
 
-# <!-- python-base-no (no extras, no local install)
+# <!-- python-base-remote (no extras, remote install)
 FROM base as python-base-remote
 ## NOOP
-# python-base (no extras) -->
+# python-base-remote (no extras) -->
 
-# <!-- python-base-yes (no extras, get code from build machine)
+# <!-- python-base-local (no extras, local install)
 FROM base as python-base-local
-# @TODO: copy whole build context
+
 COPY . /tmp/grizzly
-# python-local (get code from build machine) -->
+# python-base-local (get code from build machine) -->
 
 # <!-- python-mq (with mq extras -> pymqi)
 FROM python-base-${GRIZZLY_INSTALL_TYPE} as python-mq
@@ -53,13 +53,14 @@ COPY --from=mq /opt/mqm /opt/mqm
 ENV LD_LIBRARY_PATH="/opt/mqm/lib64:${LD_LIBRARY_PATH}"
 # python-mq (with mq extras -> pymqi) -->
 
-# <!-- python-mq-yes (with mq extras -> pymqi, local install)
+# <!-- python-mq-local (with mq extras -> pymqi, local install)
 FROM python-mq as python-mq-local
-# python-mq-yes (with mq extras -> pymqi, local install) -->
+# NOOP
+# python-mq-local (with mq extras -> pymqi, local install) -->
 
-# <!-- python-mq-no (with mq extras -> pymqi, remote install)
+# <!-- python-mq-remote (with mq extras -> pymqi, remote install)
 FROM python-mq as python-mq-remote
-# python-mq-no (with mq extras -> pymqi, remote install) -->
+# python-mq-remote (with mq extras -> pymqi, remote install) -->
 
 # <!-- python-venv
 FROM python-${GRIZZLY_EXTRA}-${GRIZZLY_INSTALL_TYPE} AS python-venv

--- a/grizzly_cli/static/compose.yaml
+++ b/grizzly_cli/static/compose.yaml
@@ -2,7 +2,7 @@ version: '3'
 services:
   master:
     hostname: master
-    image: ${GRIZZLY_IMAGE_REGISTRY:-}${GRIZZLY_IMAGE_NAME}:${GRIZZLY_USER_TAG}
+    image: ${GRIZZLY_IMAGE_REGISTRY:-}${GRIZZLY_PROJECT_NAME}:${GRIZZLY_USER_TAG}
     tty: ${GRIZZLY_CONTAINER_TTY}
     ulimits:
       nofile: ${GRIZZLY_LIMIT_NOFILE}
@@ -22,7 +22,7 @@ services:
       retries: ${GRIZZLY_HEALTH_CHECK_RETRIES:-3}
 
   worker:
-    image: ${GRIZZLY_IMAGE_REGISTRY:-}${GRIZZLY_IMAGE_NAME}:${GRIZZLY_USER_TAG}
+    image: ${GRIZZLY_IMAGE_REGISTRY:-}${GRIZZLY_PROJECT_NAME}:${GRIZZLY_USER_TAG}
     tty: ${GRIZZLY_CONTAINER_TTY}
     ulimits:
       nofile: ${GRIZZLY_LIMIT_NOFILE}

--- a/grizzly_cli/static/compose.yaml
+++ b/grizzly_cli/static/compose.yaml
@@ -38,6 +38,7 @@ services:
     depends_on:
       master:
         condition: service_healthy
+
 networks:
   default:
     driver: bridge

--- a/grizzly_cli/static/compose.yaml
+++ b/grizzly_cli/static/compose.yaml
@@ -2,7 +2,7 @@ version: '3'
 services:
   master:
     hostname: master
-    image: ${GRIZZLY_IMAGE_REGISTRY:-}${GRIZZLY_PROJECT_NAME}:${GRIZZLY_USER_TAG}
+    image: ${GRIZZLY_IMAGE_REGISTRY:-}${GRIZZLY_IMAGE_NAME}:${GRIZZLY_USER_TAG}
     tty: ${GRIZZLY_CONTAINER_TTY}
     ulimits:
       nofile: ${GRIZZLY_LIMIT_NOFILE}
@@ -22,7 +22,7 @@ services:
       retries: ${GRIZZLY_HEALTH_CHECK_RETRIES:-3}
 
   worker:
-    image: ${GRIZZLY_IMAGE_REGISTRY:-}${GRIZZLY_PROJECT_NAME}:${GRIZZLY_USER_TAG}
+    image: ${GRIZZLY_IMAGE_REGISTRY:-}${GRIZZLY_IMAGE_NAME}:${GRIZZLY_USER_TAG}
     tty: ${GRIZZLY_CONTAINER_TTY}
     ulimits:
       nofile: ${GRIZZLY_LIMIT_NOFILE}

--- a/tests/argparse/bashcompletion/test__init__.py
+++ b/tests/argparse/bashcompletion/test__init__.py
@@ -380,21 +380,21 @@ class TestBashCompleteAction:
                 'grizzly-cli dist',
                 (
                     '-h --help --workers --id --limit-nofile --health-retries --health-timeout --health-interval --registry '
-                    '--tty --wait-for-worker --force-build --build --validate-config build run'
+                    '--tty --wait-for-worker --project-name --force-build --build --validate-config build run'
                 )
             ),
             (
                 'grizzly-cli dist -',
                 (
                     '-h --help --workers --id --limit-nofile --health-retries --health-timeout --health-interval --registry '
-                    '--tty --wait-for-worker --force-build --build --validate-config'
+                    '--tty --wait-for-worker --project-name --force-build --build --validate-config'
                 ),
             ),
             (
                 'grizzly-cli dist --',
                 (
                     '--help --workers --id --limit-nofile --health-retries --health-timeout --health-interval --registry '
-                    '--tty --wait-for-worker --force-build --build --validate-config'
+                    '--tty --wait-for-worker --project-name --force-build --build --validate-config'
                 ),
             ),
             (
@@ -409,12 +409,15 @@ class TestBashCompleteAction:
                 'grizzly-cli dist --workers 8',
                 (
                     '-h --help --id --limit-nofile --health-retries --health-timeout --health-interval --registry --tty '
-                    '--wait-for-worker --force-build --build --validate-config build run'
+                    '--wait-for-worker --project-name --force-build --build --validate-config build run'
                 ),
             ),
             (
                 'grizzly-cli dist --workers 8 --force-build',
-                '-h --help --id --limit-nofile --health-retries --health-timeout --health-interval --registry --tty --wait-for-worker build run',
+                (
+                    '-h --help --id --limit-nofile --health-retries --health-timeout --health-interval --registry --tty '
+                    '--wait-for-worker --project-name build run'
+                ),
             ),
         ],
     )

--- a/tests/distributed/test___init__.py
+++ b/tests/distributed/test___init__.py
@@ -104,6 +104,7 @@ def test_distributed_run(capsys: CaptureFixture, mocker: MockerFixture, tmp_path
         assert environ.get('GRIZZLY_STATIC_CONTEXT', None) == '/tmp/static-context'
         assert environ.get('GRIZZLY_MOUNT_CONTEXT', None) == '/tmp/mount-context'
         assert environ.get('GRIZZLY_PROJECT_NAME', None) == 'grizzly-cli-test-project'
+        assert environ.get('GRIZZLY_IMAGE_NAME', None) == 'grizzly-cli-test-project'
         assert environ.get('GRIZZLY_USER_TAG', None) == 'test-user'
         assert environ.get('GRIZZLY_EXPECTED_WORKERS', None) == '3'
         assert environ.get('GRIZZLY_MASTER_RUN_ARGS', None) is None
@@ -133,6 +134,7 @@ def test_distributed_run(capsys: CaptureFixture, mocker: MockerFixture, tmp_path
             '--health-retries', '30',
             '--registry', 'gchr.io/biometria-se',
             '--wait-for-worker', '10000',
+            '--image-name', 'foobar'
             'run',
             f'{test_context}/test.feature',
         ])
@@ -194,6 +196,7 @@ def test_distributed_run(capsys: CaptureFixture, mocker: MockerFixture, tmp_path
         assert environ.get('GRIZZLY_STATIC_CONTEXT', None) == '/tmp/static-context'
         assert environ.get('GRIZZLY_MOUNT_CONTEXT', None) == '/tmp/mount-context'
         assert environ.get('GRIZZLY_PROJECT_NAME', None) == 'grizzly-cli-test-project'
+        assert environ.get('GRIZZLY_IMAGE_NAME', None) == 'foobar'
         assert environ.get('GRIZZLY_USER_TAG', None) == 'test-user'
         assert environ.get('GRIZZLY_EXPECTED_WORKERS', None) == '3'
         assert environ.get('GRIZZLY_MASTER_RUN_ARGS', None) == '--foo bar --master'

--- a/tests/test___main__.py
+++ b/tests/test___main__.py
@@ -78,6 +78,7 @@ def test__create_parser() -> None:
         '--health-timeout',
         '--health-retries',
         '--health-interval',
+        '--project-name',
         '--registry',
         '--tty',
         '--wait-for-worker',
@@ -95,6 +96,7 @@ def test__create_parser() -> None:
     assert getattr(dist_build_parser, 'prog', None) == 'grizzly-cli dist build'
     assert sorted([option_string for action in dist_build_parser._actions for option_string in action.option_strings]) == sorted([
         '-h', '--help',
+        '--local-install',
         '--no-cache',
         '--registry',
     ])


### PR DESCRIPTION
while adapting `grizzly` E2E tests to run distributed a couple of changes in `grizzly-cli` was needed;

1. `grizzly-cli dist --project-name test build --local-install`
   `--project-name` overrides the default project name which would be the name of the current directory
   `--local-install` will copy `.` as the grizzly dependency instead of installing from `requirements.txt`, so the code being tested is the latest.
2. added `--exit-code-from master` as an argument to `docker-compose up...`, so that it would return the actual grizzly status other than `0` 