### PR TITLE
set workdir to /srv/grizzly

### DIFF
--- a/grizzly_cli/static/Containerfile
+++ b/grizzly_cli/static/Containerfile
@@ -183,5 +183,7 @@ FROM grizzly-${GRIZZLY_EXTRA} as grizzly
 
 USER grizzly
 
+WORKDIR /srv/grizzly
+
 ENTRYPOINT ["./grizzly-entrypoint.sh"]
 # grizzly -->


### PR DESCRIPTION
makes doing stuff in the container a bit more deterministic, as it already is running things locally.