### PR TITLE
annotate notices in feature metadata (comments) that grizzly-cli will show

### DIFF
--- a/grizzly_cli/__main__.py
+++ b/grizzly_cli/__main__.py
@@ -127,7 +127,7 @@ def _parse_arguments() -> argparse.Namespace:
 
 def _inject_additional_arguments_from_metadata(args: argparse.Namespace) -> argparse.Namespace:
     with open(args.file) as fd:
-        file_metadata = [line.strip().replace('# grizzly-cli ', '').split(' ') for line in fd.readlines() if line.strip().startswith('# grizzly-cli')]
+        file_metadata = [line.strip().replace('# grizzly-cli ', '').split(' ') for line in fd.readlines() if line.strip().startswith('# grizzly-cli ')]
 
     if len(file_metadata) < 1:
         return args

--- a/grizzly_cli/run.py
+++ b/grizzly_cli/run.py
@@ -1,6 +1,6 @@
 import os
 
-from typing import List, Dict, Any, Callable
+from typing import List, Dict, Any, Callable, cast
 from argparse import Namespace as Arguments
 from platform import node as get_hostname
 
@@ -10,6 +10,7 @@ from .utils import (
     ask_yes_no, get_input,
     distribution_of_users_per_scenario,
     requirements,
+    find_metadata_notices,
 )
 from .argparse import ArgumentSubParser
 from .argparse.bashcompletion import BashCompletionTypes
@@ -95,6 +96,17 @@ def run(args: Arguments, run_func: Callable[[Arguments, Dict[str, Any], Dict[str
 
         if manual_input:
             ask_yes_no('continue?')
+
+    notices = find_metadata_notices(args.file)
+
+    if len(notices) > 0:
+        if args.yes:
+            output_func = cast(Callable[[str], None], print)
+        else:
+            output_func = ask_yes_no
+
+        for notice in notices:
+            output_func(notice)
 
     if args.environment_file is not None:
         environment_file = os.path.realpath(args.environment_file)

--- a/grizzly_cli/utils.py
+++ b/grizzly_cli/utils.py
@@ -547,6 +547,11 @@ def parse_feature_file(file: str) -> None:
         grizzly_cli.SCENARIOS.append(scenario)
 
 
+def find_metadata_notices(file: str) -> List[str]:
+    with open(file) as fd:
+        return [line.strip().replace('# grizzly-cli:notice ', '') for line in fd.readlines() if line.strip().startswith('# grizzly-cli:notice ')]
+
+
 def find_variable_names_in_questions(file: str) -> List[str]:
     unique_variables: Set[str] = set()
 


### PR DESCRIPTION
implementation of Biometria-se/grizzly#178.

useful to remind the "operator" of grizzly about stuff.

any comment in the feature file being executed like:

```gherkin
# grizzly-cli:notice do you know what you are doing?
```

will cause `grizzly-cli` to confirm the notice:

```
do you know what you are doing? [y/n]: 
```

unless `--yes` flag is specified to the `run` parser, then its just printed to stdout.