### PR TITLE
implemented support for `--csv*` arguments

### DIFF
--- a/grizzly_cli/__init__.py
+++ b/grizzly_cli/__init__.py
@@ -1,6 +1,6 @@
 import os
 
-from typing import Callable, List
+from typing import Callable, List, Optional
 
 from behave.model import Scenario
 
@@ -17,6 +17,8 @@ MOUNT_CONTEXT = os.environ.get('GRIZZLY_MOUNT_CONTEXT', EXECUTION_CONTEXT)
 PROJECT_NAME = os.path.basename(EXECUTION_CONTEXT)
 
 SCENARIOS: List[Scenario] = []
+
+FEATURE_DESCRIPTION: Optional[str] = None
 
 
 class register_parser:

--- a/grizzly_cli/__main__.py
+++ b/grizzly_cli/__main__.py
@@ -118,6 +118,13 @@ def _parse_arguments() -> argparse.Namespace:
                     os.environ[f'TESTDATA_VARIABLE_{name}'] = value
                 except ValueError:
                     parser.error_no_help('-T/--testdata-variable needs to be in the format NAME=VALUE')
+
+        if args.csv_prefix is None:
+            if args.csv_interval is not None:
+                parser.error_no_help('--csv-interval can only be used in combination with --csv-prefix')
+
+            if args.csv_flush_interval is not None:
+                parser.error_no_help('--csv-flush-interval can only be used in combination with --csv-prefix')
     elif args.command == 'dist' and args.subcommand == 'build':
         setattr(args, 'force_build', args.no_cache)
         setattr(args, 'build', not args.no_cache)

--- a/grizzly_cli/utils.py
+++ b/grizzly_cli/utils.py
@@ -543,6 +543,8 @@ def parse_feature_file(file: str) -> None:
 
     feature = feature_file_parser(file)
 
+    grizzly_cli.FEATURE_DESCRIPTION = feature.name
+
     for scenario in feature.scenarios:
         grizzly_cli.SCENARIOS.append(scenario)
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -394,11 +394,21 @@ def step_start_webserver(context: Context) -> None:
 
         return feature_file_name
 
-    def execute(self, feature_file: str, env_conf_file: Optional[str] = None, testdata: Optional[Dict[str, str]] = None, cwd: Optional[str] = None) -> Tuple[int, List[str]]:
+    def execute(
+        self,
+        feature_file: str,
+        env_conf_file: Optional[str] = None,
+        testdata: Optional[Dict[str, str]] = None,
+        cwd: Optional[str] = None,
+        arguments: Optional[List[str]] = None,
+    ) -> Tuple[int, List[str]]:
+        if arguments is None:
+            arguments = []
         command = [
             'grizzly-cli',
             self.mode,
             'run',
+            *arguments,
             '--yes',
             '--verbose',
             feature_file,

--- a/tests/unit/argparse/bashcompletion/test__init__.py
+++ b/tests/unit/argparse/bashcompletion/test__init__.py
@@ -234,25 +234,37 @@ class TestBashCompleteAction:
 
     @pytest.mark.parametrize(
         'input,expected', [
-            ('grizzly-cli local run ', '-h\n--help\n--verbose\n-T\n--testdata-variable\n-y\n--yes\n-e\n--environment-file\ntest.feature\ntest-dir'),
-            ('grizzly-cli local run -', '-h\n--help\n--verbose\n-T\n--testdata-variable\n-y\n--yes\n-e\n--environment-file'),
-            ('grizzly-cli local run --', '--help\n--verbose\n--testdata-variable\n--yes\n--environment-file'),
-            ('grizzly-cli local run --yes', '-h\n--help\n--verbose\n-T\n--testdata-variable\n-e\n--environment-file'),
+            (
+                'grizzly-cli local run ',
+                '-h\n--help\n--verbose\n-T\n--testdata-variable\n-y\n--yes\n-e\n--environment-file\n--csv-prefix\n--csv-interval\n--csv-flush-interval\ntest.feature\ntest-dir',
+            ),
+            ('grizzly-cli local run -', '-h\n--help\n--verbose\n-T\n--testdata-variable\n-y\n--yes\n-e\n--environment-file\n--csv-prefix\n--csv-interval\n--csv-flush-interval'),
+            ('grizzly-cli local run --', '--help\n--verbose\n--testdata-variable\n--yes\n--environment-file\n--csv-prefix\n--csv-interval\n--csv-flush-interval'),
+            ('grizzly-cli local run --yes', '-h\n--help\n--verbose\n-T\n--testdata-variable\n-e\n--environment-file\n--csv-prefix\n--csv-interval\n--csv-flush-interval'),
             ('grizzly-cli local run --help --yes', ''),
             ('grizzly-cli local run --yes -T', ''),
-            ('grizzly-cli local run --yes -T key=value', '-h\n--help\n--verbose\n-T\n--testdata-variable\n-e\n--environment-file\ntest.feature\ntest-dir'),
+            (
+                'grizzly-cli local run --yes -T key=value',
+                '-h\n--help\n--verbose\n-T\n--testdata-variable\n-e\n--environment-file\n--csv-prefix\n--csv-interval\n--csv-flush-interval\ntest.feature\ntest-dir',
+            ),
             ('grizzly-cli local run --yes -T key=value --env', '--environment-file'),
             ('grizzly-cli local run --yes -T key=value --environment-file', 'test.yaml\ntest\\ space.yaml\ntest-dir'),
             ('grizzly-cli local run --yes -T key=value --environment-file test', 'test.yaml\ntest\\ space.yaml\ntest-dir'),
             ('grizzly-cli local run --yes -T key=value --environment-file test-', 'test-dir'),
-            ('grizzly-cli local run --yes -T key=value --environment-file test-dir', '-h\n--help\n--verbose\n-T\n--testdata-variable'),
+            (
+                'grizzly-cli local run --yes -T key=value --environment-file test-dir',
+                '-h\n--help\n--verbose\n-T\n--testdata-variable\n--csv-prefix\n--csv-interval\n--csv-flush-interval',
+            ),
             ('grizzly-cli local run --yes -T key=value --environment-file test.', 'test.yaml'),
-            ('grizzly-cli local run --yes -T key=value --environment-file test.yaml', '-h\n--help\n--verbose\n-T\n--testdata-variable'),
+            (
+                'grizzly-cli local run --yes -T key=value --environment-file test.yaml',
+                '-h\n--help\n--verbose\n-T\n--testdata-variable\n--csv-prefix\n--csv-interval\n--csv-flush-interval',
+            ),
             ('grizzly-cli local run --yes -T key=value --environment-file test.yaml --test', '--testdata-variable'),
             ('grizzly-cli local run --yes -T key=value --environment-file test.yaml --testdata-variable', ''),
             (
                 'grizzly-cli local run --yes -T key=value --environment-file test.yaml --testdata-variable key=value',
-                '-h\n--help\n--verbose\n-T\n--testdata-variable\ntest.feature\ntest-dir',
+                '-h\n--help\n--verbose\n-T\n--testdata-variable\n--csv-prefix\n--csv-interval\n--csv-flush-interval\ntest.feature\ntest-dir',
             ),
             ('grizzly-cli local run --yes -T key=value --environment-file test.yaml --testdata-variable key=value test', 'test.feature\ntest-dir'),
             ('grizzly-cli local run --yes -T key=value --environment-file test.yaml --testdata-variable key=value test.fe', 'test.feature'),
@@ -302,25 +314,37 @@ class TestBashCompleteAction:
 
     @pytest.mark.parametrize(
         'input,expected', [
-            ('grizzly-cli dist run ', '-h\n--help\n--verbose\n-T\n--testdata-variable\n-y\n--yes\n-e\n--environment-file\ntest.feature\ntest-dir'),
-            ('grizzly-cli dist run -', '-h\n--help\n--verbose\n-T\n--testdata-variable\n-y\n--yes\n-e\n--environment-file'),
-            ('grizzly-cli dist run --', '--help\n--verbose\n--testdata-variable\n--yes\n--environment-file'),
-            ('grizzly-cli dist run --yes', '-h\n--help\n--verbose\n-T\n--testdata-variable\n-e\n--environment-file'),
+            (
+                'grizzly-cli dist run ',
+                '-h\n--help\n--verbose\n-T\n--testdata-variable\n-y\n--yes\n-e\n--environment-file\n--csv-prefix\n--csv-interval\n--csv-flush-interval\ntest.feature\ntest-dir',
+            ),
+            ('grizzly-cli dist run -', '-h\n--help\n--verbose\n-T\n--testdata-variable\n-y\n--yes\n-e\n--environment-file\n--csv-prefix\n--csv-interval\n--csv-flush-interval'),
+            ('grizzly-cli dist run --', '--help\n--verbose\n--testdata-variable\n--yes\n--environment-file\n--csv-prefix\n--csv-interval\n--csv-flush-interval'),
+            ('grizzly-cli dist run --yes', '-h\n--help\n--verbose\n-T\n--testdata-variable\n-e\n--environment-file\n--csv-prefix\n--csv-interval\n--csv-flush-interval'),
             ('grizzly-cli dist run --help --yes', ''),
             ('grizzly-cli dist run --yes -T', ''),
-            ('grizzly-cli dist run --yes -T key=value', '-h\n--help\n--verbose\n-T\n--testdata-variable\n-e\n--environment-file\ntest.feature\ntest-dir'),
+            (
+                'grizzly-cli dist run --yes -T key=value',
+                '-h\n--help\n--verbose\n-T\n--testdata-variable\n-e\n--environment-file\n--csv-prefix\n--csv-interval\n--csv-flush-interval\ntest.feature\ntest-dir',
+            ),
             ('grizzly-cli dist run --yes -T key=value --env', '--environment-file'),
             ('grizzly-cli dist run --yes -T key=value --environment-file', 'test.yaml\ntest\\ space.yaml\ntest-dir'),
             ('grizzly-cli dist run --yes -T key=value --environment-file test', 'test.yaml\ntest\\ space.yaml\ntest-dir'),
             ('grizzly-cli dist run --yes -T key=value --environment-file test-', 'test-dir'),
-            ('grizzly-cli dist run --yes -T key=value --environment-file test-dir', '-h\n--help\n--verbose\n-T\n--testdata-variable'),
+            (
+                'grizzly-cli dist run --yes -T key=value --environment-file test-dir',
+                '-h\n--help\n--verbose\n-T\n--testdata-variable\n--csv-prefix\n--csv-interval\n--csv-flush-interval',
+            ),
             ('grizzly-cli dist run --yes -T key=value --environment-file test.', 'test.yaml'),
-            ('grizzly-cli dist run --yes -T key=value --environment-file test.yaml', '-h\n--help\n--verbose\n-T\n--testdata-variable'),
+            (
+                'grizzly-cli dist run --yes -T key=value --environment-file test.yaml',
+                '-h\n--help\n--verbose\n-T\n--testdata-variable\n--csv-prefix\n--csv-interval\n--csv-flush-interval',
+            ),
             ('grizzly-cli dist run --yes -T key=value --environment-file test.yaml --test', '--testdata-variable'),
             ('grizzly-cli dist run --yes -T key=value --environment-file test.yaml --testdata-variable', ''),
             (
                 'grizzly-cli dist run --yes -T key=value --environment-file test.yaml --testdata-variable key=value',
-                '-h\n--help\n--verbose\n-T\n--testdata-variable\ntest.feature\ntest-dir',
+                '-h\n--help\n--verbose\n-T\n--testdata-variable\n--csv-prefix\n--csv-interval\n--csv-flush-interval\ntest.feature\ntest-dir',
             ),
             ('grizzly-cli dist run --yes -T key=value --environment-file test.yaml --testdata-variable key=value test', 'test.feature\ntest-dir'),
             ('grizzly-cli dist run --yes -T key=value --environment-file test.yaml --testdata-variable key=value test.fe', 'test.feature'),

--- a/tests/unit/distributed/test___init__.py
+++ b/tests/unit/distributed/test___init__.py
@@ -172,7 +172,7 @@ def test_distributed_run(capsys: CaptureFixture, mocker: MockerFixture, tmp_path
             {
                 'master': ['--foo', 'bar', '--master'],
                 'worker': ['--bar', 'foo', '--worker'],
-                'common': ['--common', 'true'],
+                'common': ['--common', 'true', '-Dcsv-prefix=asdf'],
             },
         ) == 1
         capture = capsys.readouterr()
@@ -220,7 +220,7 @@ def test_distributed_run(capsys: CaptureFixture, mocker: MockerFixture, tmp_path
         assert environ.get('GRIZZLY_EXPECTED_WORKERS', None) == '3'
         assert environ.get('GRIZZLY_MASTER_RUN_ARGS', None) == '--foo bar --master'
         assert environ.get('GRIZZLY_WORKER_RUN_ARGS', None) == '--bar foo --worker'
-        assert environ.get('GRIZZLY_COMMON_RUN_ARGS', None) == '--common true'
+        assert environ.get('GRIZZLY_COMMON_RUN_ARGS', None) == '--common true -Dcsv-prefix=asdf'
         assert environ.get('GRIZZLY_ENVIRONMENT_FILE', '').startswith(gettempdir())
         assert environ.get('GRIZZLY_LIMIT_NOFILE', None) == '133700'
         assert environ.get('GRIZZLY_HEALTH_CHECK_INTERVAL', None) == '10'

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -2,6 +2,7 @@ from shutil import rmtree
 from os import getcwd, path
 from argparse import ArgumentParser
 from datetime import datetime
+from pathlib import Path
 
 from _pytest.capture import CaptureFixture
 from _pytest.tmpdir import TempPathFactory
@@ -15,6 +16,8 @@ CWD = getcwd()
 
 
 def test_run(capsys: CaptureFixture, mocker: MockerFixture, tmp_path_factory: TempPathFactory) -> None:
+    original_tmp_path = tmp_path_factory._basetemp
+    tmp_path_factory._basetemp = Path.cwd() / '.pytest_tmp'
     test_context = tmp_path_factory.mktemp('test_context')
     execution_context = test_context / 'execution-context'
     execution_context.mkdir()
@@ -240,4 +243,5 @@ bar = foo
             'common': ['--stop', '-Dcsv-prefix="this_feature_is_testing_something_20221206T130113"', '-Dcsv-interval=20', '-Dcsv-flush-interval=60'],
         }
     finally:
+        tmp_path_factory._basetemp = original_tmp_path
         rmtree(test_context, onerror=onerror)


### PR DESCRIPTION
which has been implemented in Biometria-se/grizzly#181.

tests will fail until above PR is mereged and new release published of `grizzly-loadtester`.