### PR TITLE
Fix typo in container registry domain

### DIFF
--- a/tests/unit/distributed/test___init__.py
+++ b/tests/unit/distributed/test___init__.py
@@ -151,7 +151,7 @@ def test_distributed_run(capsys: CaptureFixture, mocker: MockerFixture, tmp_path
             '--health-interval', '10',
             '--health-timeout', '8',
             '--health-retries', '30',
-            '--registry', 'gchr.io/biometria-se',
+            '--registry', 'ghcr.io/biometria-se',
             '--wait-for-worker', '10000',
             '--project-name', 'foobar',
             'run',
@@ -226,7 +226,7 @@ def test_distributed_run(capsys: CaptureFixture, mocker: MockerFixture, tmp_path
         assert environ.get('GRIZZLY_HEALTH_CHECK_INTERVAL', None) == '10'
         assert environ.get('GRIZZLY_HEALTH_CHECK_TIMEOUT', None) == '8'
         assert environ.get('GRIZZLY_HEALTH_CHECK_RETRIES', None) == '30'
-        assert environ.get('GRIZZLY_IMAGE_REGISTRY', None) == 'gchr.io/biometria-se'
+        assert environ.get('GRIZZLY_IMAGE_REGISTRY', None) == 'ghcr.io/biometria-se'
         assert environ.get('GRIZZLY_CONTAINER_TTY', None) == 'false'
         assert environ.get('LOCUST_WAIT_FOR_WORKERS_REPORT_AFTER_RAMP_UP', None) == '10000'
         assert environ.get('GRIZZLY_MOUNT_PATH', None) == ''

--- a/tests/unit/test___main__.py
+++ b/tests/unit/test___main__.py
@@ -457,13 +457,13 @@ def test__parse_argument(capsys: CaptureFixture, mocker: MockerFixture, tmp_path
         assert arguments.build
         assert arguments.registry is None
 
-        sys.argv = ['grizzly-cli', 'dist', 'build', '--no-cache', '--registry', 'gchr.io/biometria-se']
+        sys.argv = ['grizzly-cli', 'dist', 'build', '--no-cache', '--registry', 'ghcr.io/biometria-se']
         arguments = _parse_arguments()
 
         assert arguments.no_cache
         assert arguments.force_build
         assert not arguments.build
-        assert arguments.registry == 'gchr.io/biometria-se/'
+        assert arguments.registry == 'ghcr.io/biometria-se/'
 
         sys.argv = ['grizzly-cli', 'init', 'test-project']
         arguments = _parse_arguments()


### PR DESCRIPTION
Hi `Biometria-se/grizzly-cli`!

This is not an automatic, 🤖-generated PR, as you can check in my [GitHub profile](https://github.com/p-), I work for GitHub and I am part of the [GitHub Security Lab](https://securitylab.github.com/).

While performing a code search for container registry domains we noticed that this repo contains a misspelled domain name.

If a malicious actor were in control of that misspelled domain, they could potentially perform an attack on the software supply chain of this project and/or steal the credentials used to connect to the container registry (depending on how the misspelled domain name of the container registry is used - In some cases it's only a matter of wrongly tagged container images)
Please verify the changes made with this PR and check your documentation for similar typos.