### PR TITLE
handle ctrl + c (SIGINT)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 **/*.prof
 **/*.lprof
 **/*.svg
+**/.env
 *.egg-info/
 build/
 dist/
@@ -14,6 +15,7 @@ features/
 !.github/**/*.yaml
 .venv/
 grizzly-example/
+tests/manual
 *.event
 *.tar.gz
 *.hprof

--- a/grizzly_cli/distributed/__init__.py
+++ b/grizzly_cli/distributed/__init__.py
@@ -13,7 +13,6 @@ from json import loads as jsonloads
 
 from .. import EXECUTION_CONTEXT, STATIC_CONTEXT, MOUNT_CONTEXT, PROJECT_NAME, register_parser
 from ..utils import (
-    is_docker_compose_v2,
     run_command,
     get_default_mtu,
     list_images,
@@ -199,17 +198,12 @@ def distributed_run(args: Arguments, environ: Dict[str, Any], run_arguments: Dic
 
     grizzly_mount_context_path = ''
 
-    if is_docker_compose_v2():
-        name_template = '{project}{suffix}-{tag}-{node}-{index}'
-        start_index = 2
-    else:
-        name_template = '{project}{suffix}-{tag}_{node}_{index}'
-        start_index = 1
+    name_template = '{project}{suffix}-{tag}-{node}-{index}'
 
     if EXECUTION_CONTEXT != MOUNT_CONTEXT:
         hostname = gethostname()
         output = subprocess.check_output(
-            [args.container_system, 'inspect', '-f', '{{ json .Mounts }}', hostname],
+            [args.container_system, 'container', 'inspect', '-f', '{{ json .Mounts }}', hostname],
             encoding='utf-8',
         )
         container_mounts = jsonloads(output)
@@ -359,7 +353,7 @@ def distributed_run(args: Arguments, environ: Dict[str, Any], run_arguments: Dic
                 ),
             ))
 
-            for worker in range(start_index, args.workers + start_index):
+            for worker in range(1, args.workers + 1):
                 print(template.format(
                     container_system=args.container_system,
                     name_template=name_template.format(

--- a/grizzly_cli/distributed/__init__.py
+++ b/grizzly_cli/distributed/__init__.py
@@ -341,9 +341,10 @@ def distributed_run(args: Arguments, environ: Dict[str, Any], run_arguments: Dic
                     shell=False,
                     universal_newlines=True,
                     stderr=subprocess.STDOUT,
-                )
+                ).split('\n')
 
-                print(missed_output)
+                for line in missed_output:
+                    print(f'{master_node_name}  | {line}')
 
             print('\n!! something went wrong, check full container logs with:')
             template = '{container_system} container logs {name_template}'

--- a/grizzly_cli/distributed/build.py
+++ b/grizzly_cli/distributed/build.py
@@ -131,13 +131,13 @@ def build(args: Arguments) -> int:
     if args.container_system == 'docker':
         build_env['DOCKER_BUILDKIT'] = '1'
 
-    rc = run_command(build_command, env=build_env)
+    result = run_command(build_command, env=build_env)
 
-    if rc == 0:
+    if result.return_code == 0:
         print(f'built image {image_name}')
 
-    if getattr(args, 'registry', None) is None or rc != 0:
-        return rc
+    if getattr(args, 'registry', None) is None or result.return_code != 0:
+        return result.return_code
 
     tag_command = [
         f'{args.container_system}',
@@ -147,11 +147,11 @@ def build(args: Arguments) -> int:
         f'{args.registry}{image_name}',
     ]
 
-    rc = run_command(tag_command, env=build_env)
+    result = run_command(tag_command, env=build_env)
 
-    if rc != 0:
+    if result.return_code != 0:
         print(f'\n!! failed to tag image {image_name} -> {args.registry}{image_name}')
-        return rc
+        return result.return_code
     else:
         print(f'tagged image {image_name} -> {args.registry}{image_name}')
 
@@ -162,11 +162,11 @@ def build(args: Arguments) -> int:
         f'{args.registry}{image_name}',
     ]
 
-    rc = run_command(push_command, env=build_env)
+    result = run_command(push_command, env=build_env)
 
-    if rc != 0:
+    if result.return_code != 0:
         print(f'\n!! failed to push image {args.registry}{image_name}')
     else:
         print(f'pushed image {args.registry}{image_name}')
 
-    return rc
+    return result.return_code

--- a/grizzly_cli/distributed/clean.py
+++ b/grizzly_cli/distributed/clean.py
@@ -67,7 +67,7 @@ def clean(args: Arguments) -> int:
             'rm', '-f', '-s', '-v',
         ]
 
-        rc = run_command(compose_command, env=env)
+        result = run_command(compose_command, env=env)
 
     if args.images:
         command = [
@@ -85,4 +85,4 @@ def clean(args: Arguments) -> int:
 
         run_command(command)
 
-    return rc
+    return result.return_code

--- a/grizzly_cli/local.py
+++ b/grizzly_cli/local.py
@@ -45,4 +45,4 @@ def local_run(args: Arguments, environ: Dict[str, Any], run_arguments: Dict[str,
     if len(run_arguments.get('master', [])) > 0 or len(run_arguments.get('worker', [])) > 0 or len(run_arguments.get('common', [])) > 0:
         command += run_arguments['master'] + run_arguments['worker'] + run_arguments['common']
 
-    return run_command(command)
+    return run_command(command).return_code

--- a/grizzly_cli/static/Containerfile
+++ b/grizzly_cli/static/Containerfile
@@ -85,6 +85,7 @@ RUN python -m venv /venv
 
 ENV PATH="/venv/bin:$PATH"
 
+RUN python -m pip install wheel
 # python-venv -->
 
 # <!-- python-venv-base-local (no mq extras, local install)

--- a/grizzly_cli/static/compose.yaml
+++ b/grizzly_cli/static/compose.yaml
@@ -26,6 +26,7 @@ services:
     tty: ${GRIZZLY_CONTAINER_TTY}
     ulimits:
       nofile: ${GRIZZLY_LIMIT_NOFILE}
+    stop_grace_period: 1h
     extra_hosts:
       - "host.docker.internal:host-gateway"
     volumes:

--- a/grizzly_cli/utils.py
+++ b/grizzly_cli/utils.py
@@ -27,11 +27,6 @@ from jinja2 import Template
 import grizzly_cli
 
 
-RETURNCODE_TOKEN = 'grizzly.returncode='
-
-RETURNCODE_PATTERN = re.compile(r'.*grizzly\.returncode=([-]?[0-9]+).*')
-
-
 class SignalHandler:
     handler: Callable[[int, Optional[FrameType]], None]
     signals: Dict[int, Union[Callable[[int, Optional[FrameType]], Any], int, None]]
@@ -64,7 +59,6 @@ class RunCommandResult:
 
 
 def run_command(command: List[str], env: Optional[Dict[str, str]] = None, silent: bool = False, verbose: bool = False) -> RunCommandResult:
-    returncode: Optional[int] = None
     if env is None:
         env = environ.copy()
 
@@ -99,18 +93,6 @@ def run_command(command: List[str], env: Optional[Dict[str, str]] = None, silent
                 if not output:
                     break
 
-                # Biometria-se/grizzly#160
-                line = output.decode('utf-8')
-                if RETURNCODE_TOKEN in line:
-                    match = RETURNCODE_PATTERN.match(line)
-                    if match:
-                        try:
-                            returncode = int(match.group(1))
-                        except ValueError:
-                            returncode = 123
-
-                    continue  # hide from actual output
-
                 if result.output is None:
                     sys.stdout.buffer.write(output)
                     sys.stdout.flush()
@@ -128,7 +110,7 @@ def run_command(command: List[str], env: Optional[Dict[str, str]] = None, silent
 
     process.wait()
 
-    result.return_code = returncode or process.returncode
+    result.return_code = process.returncode
 
     return result
 

--- a/grizzly_cli/utils.py
+++ b/grizzly_cli/utils.py
@@ -130,12 +130,6 @@ def get_docker_compose_version() -> Tuple[int, int, int]:
     return version
 
 
-def is_docker_compose_v2() -> bool:
-    version = get_docker_compose_version()
-
-    return version[0] == 2
-
-
 def get_dependency_versions() -> Tuple[Tuple[Optional[str], Optional[List[str]]], Optional[str]]:
     def onerror(func: Callable, path: str, exc_info: TracebackType) -> None:
         import os

--- a/tests/unit/distributed/test___init__.py
+++ b/tests/unit/distributed/test___init__.py
@@ -192,7 +192,7 @@ def test_distributed_run(capsys: CaptureFixture, mocker: MockerFixture, tmp_path
         capture = capsys.readouterr()
         assert capture.err == ''
         assert capture.out == (
-            '<!-- here is the missing logs -->\n'
+            'foobar-test-user-master-1  | <!-- here is the missing logs -->\n'
             '\n!! something went wrong, check full container logs with:\n'
             'docker container logs foobar-test-user-master-1\n'
             'docker container logs foobar-test-user-worker-2\n'

--- a/tests/unit/distributed/test_build.py
+++ b/tests/unit/distributed/test_build.py
@@ -11,6 +11,7 @@ from pytest_mock import MockerFixture
 
 from argparse import Namespace
 
+from grizzly_cli.utils import RunCommandResult
 from grizzly_cli.distributed.build import _create_build_command, getgid, getuid, build
 
 from ...helpers import onerror
@@ -194,7 +195,18 @@ def test_build(capsys: CaptureFixture, mocker: MockerFixture, tmp_path_factory: 
         mocker.patch('grizzly_cli.distributed.build.getuser', return_value='test-user')
         mocker.patch('grizzly_cli.distributed.build.getuid', return_value=1337)
         mocker.patch('grizzly_cli.distributed.build.getgid', return_value=2147483647)
-        run_command = mocker.patch('grizzly_cli.distributed.build.run_command', side_effect=[254, 133, 0, 1, 0, 0, 2, 0, 0, 0])
+        run_command = mocker.patch('grizzly_cli.distributed.build.run_command', side_effect=[
+            RunCommandResult(return_code=254),
+            RunCommandResult(return_code=133),
+            RunCommandResult(return_code=0),
+            RunCommandResult(return_code=1),
+            RunCommandResult(return_code=0),
+            RunCommandResult(return_code=0),
+            RunCommandResult(return_code=2),
+            RunCommandResult(return_code=0),
+            RunCommandResult(return_code=0),
+            RunCommandResult(return_code=0),
+        ])
         setattr(getattr(build, '__wrapped__'), '__value__', str(test_context))
 
         test_args = Namespace(container_system='test', force_build=False, project_name=None, local_install=False)

--- a/tests/unit/distributed/test_clean.py
+++ b/tests/unit/distributed/test_clean.py
@@ -2,6 +2,7 @@ from argparse import Namespace
 
 from pytest_mock import MockerFixture
 
+from grizzly_cli.utils import RunCommandResult
 from grizzly_cli.distributed.clean import clean
 
 
@@ -14,7 +15,16 @@ def test_clean(mocker: MockerFixture) -> None:
     mocker.patch('grizzly_cli.distributed.clean.getuser', return_value='root')
     mocker.patch('grizzly_cli.distributed.clean.get_terminal_size', return_value=(1024, 1024,))
 
-    run_command_spy = mocker.patch('grizzly_cli.distributed.clean.run_command', side_effect=[0, 1, 2, 3, 4, 5, 6, 7])
+    run_command_spy = mocker.patch('grizzly_cli.distributed.clean.run_command', side_effect=[
+        RunCommandResult(return_code=0),
+        RunCommandResult(return_code=1),
+        RunCommandResult(return_code=2),
+        RunCommandResult(return_code=3),
+        RunCommandResult(return_code=4),
+        RunCommandResult(return_code=5),
+        RunCommandResult(return_code=6),
+        RunCommandResult(return_code=7),
+    ])
 
     assert clean(arguments) == 0
 

--- a/tests/unit/test_local.py
+++ b/tests/unit/test_local.py
@@ -8,6 +8,7 @@ import pytest
 from _pytest.tmpdir import TempPathFactory
 from pytest_mock import MockerFixture
 
+from grizzly_cli.utils import RunCommandResult
 from grizzly_cli.local import create_parser, local_run, local
 
 from ..helpers import onerror
@@ -33,7 +34,7 @@ def test_local(mocker: MockerFixture) -> None:
 
 
 def test_local_run(mocker: MockerFixture, tmp_path_factory: TempPathFactory) -> None:
-    run_command = mocker.patch('grizzly_cli.local.run_command', return_value=0)
+    run_command = mocker.patch('grizzly_cli.local.run_command', return_value=RunCommandResult(return_code=0))
     test_context = tmp_path_factory.mktemp('test_context')
     (test_context / 'test.feature').write_text('Feature:')
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -16,8 +16,6 @@ from unittest.mock import mock_open, patch as unittest_patch
 from requests_mock import Mocker as RequestsMocker
 
 from grizzly_cli.utils import (
-    get_docker_compose_version,
-    is_docker_compose_v2,
     parse_feature_file,
     list_images,
     get_default_mtu,
@@ -1263,31 +1261,3 @@ def test_requirements(capsys: CaptureFixture, tmp_path_factory: TempPathFactory)
 
     finally:
         rmtree(test_context, onerror=onerror)
-
-
-def test_get_docker_compose_version(mocker: MockerFixture) -> None:
-    mocker.patch('grizzly_cli.utils.subprocess.getoutput', side_effect=[
-        '''docker-compose version 1.29.2, build 5becea4c
-docker-py version: 5.0.0
-CPython version: 3.7.10
-OpenSSL version: OpenSSL 1.1.0l 10 Sep 2019''',
-        'Docker Compose version v2.1.0',
-        'Foo bar',
-    ])
-
-    assert get_docker_compose_version() == (1, 29, 2,)
-    assert get_docker_compose_version() == (2, 1, 0,)
-    assert get_docker_compose_version() == (0, 0, 0,)
-
-
-def test_is_docker_compose_v2(mocker: MockerFixture) -> None:
-    mocker.patch('grizzly_cli.utils.subprocess.getoutput', side_effect=[
-        '''docker-compose version 1.29.2, build 5becea4c
-docker-py version: 5.0.0
-CPython version: 3.7.10
-OpenSSL version: OpenSSL 1.1.0l 10 Sep 2019''',
-        'Docker Compose version v2.1.0',
-    ])
-
-    assert not is_docker_compose_v2()
-    assert is_docker_compose_v2()

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -174,7 +174,7 @@ def test_run_command(capsys: CaptureFixture, mocker: MockerFixture) -> None:
     poll_mock = mocker.patch('grizzly_cli.utils.subprocess.Popen.poll', side_effect=[None])
     kill_mock = mocker.patch('grizzly_cli.utils.subprocess.Popen.kill', side_effect=[RuntimeError, None])
 
-    assert run_command(['hello', 'world'], verbose=True) == 133
+    assert run_command(['hello', 'world'], verbose=True).return_code == 133
 
     capture = capsys.readouterr()
     assert capture.err == ''
@@ -206,7 +206,7 @@ def test_run_command(capsys: CaptureFixture, mocker: MockerFixture) -> None:
     ])
     poll_mock = mocker.patch('grizzly_cli.utils.subprocess.Popen.poll', side_effect=[None] * 3)
 
-    assert run_command([], {}) == 0
+    assert run_command([], {}).return_code == 0
 
     capture = capsys.readouterr()
     assert capture.err == ''
@@ -228,7 +228,7 @@ def test_run_command(capsys: CaptureFixture, mocker: MockerFixture) -> None:
     ], 0)
     poll_mock = mocker.patch('grizzly_cli.utils.subprocess.Popen.poll', side_effect=[None] * 6)
 
-    assert run_command([], {}) == 4321
+    assert run_command([], {}).return_code == 4321
 
     capture = capsys.readouterr()
     assert capture.err == ''


### PR DESCRIPTION
`grizzly-cli` parts for Biometria-se/grizzly#196.

when grizzly-cli traps `ctrl + c` (SIGINT), the process wrapping
- local = `behave`
- dist = `docker compose`

should be terminated, which means that it sends SIGINT to the process, which then must be handled by `grizzly`.

when `docker compose` is interrupted, it will stop outputting logs from the container, so after it has finished, we should get all logs from the time when SIGINT was handled, so we get a some what normal output even when aborting.