### PR TITLE
included missed output in log file when `-l/--log-file` is used

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ tests/manual
 tmp/
 requirements.txt
 grizzly_cli/__version__.py
+tests/e2e/example

--- a/grizzly_cli/distributed/__init__.py
+++ b/grizzly_cli/distributed/__init__.py
@@ -10,6 +10,8 @@ from shutil import get_terminal_size
 from argparse import Namespace as Arguments
 from socket import gethostname
 from json import loads as jsonloads
+from io import StringIO
+from pathlib import Path
 
 from .. import EXECUTION_CONTEXT, STATIC_CONTEXT, MOUNT_CONTEXT, PROJECT_NAME, register_parser
 from ..utils import (
@@ -337,8 +339,17 @@ def distributed_run(args: Arguments, environ: Dict[str, Any], run_arguments: Dic
                     stderr=subprocess.STDOUT,
                 ).split('\n')
 
-                for line in missed_output:
-                    print(f'{master_node_name}  | {line}')
+                log_file = Path(args.log_file).open('a+') if args.log_file is not None else StringIO()
+
+                try:
+                    for line in missed_output:
+                        formatted_line = f'{master_node_name}  | {line}'
+                        print(formatted_line)
+                        log_file.write(f'{formatted_line}\n')
+                except:
+                    pass
+                finally:
+                    log_file.close()
 
             print('\n!! something went wrong, check full container logs with:')
             template = '{container_system} container logs {name_template}'

--- a/grizzly_cli/distributed/build.py
+++ b/grizzly_cli/distributed/build.py
@@ -131,10 +131,10 @@ def build(args: Arguments) -> int:
     if args.container_system == 'docker':
         build_env['DOCKER_BUILDKIT'] = '1'
 
-    result = run_command(build_command, env=build_env)
+    result = run_command(build_command, env=build_env, spinner='building')
 
     if result.return_code == 0:
-        print(f'built image {image_name}')
+        print(f'\nbuilt image {image_name}')
 
     if getattr(args, 'registry', None) is None or result.return_code != 0:
         return result.return_code
@@ -162,7 +162,7 @@ def build(args: Arguments) -> int:
         f'{args.registry}{image_name}',
     ]
 
-    result = run_command(push_command, env=build_env)
+    result = run_command(push_command, env=build_env, spinner='pushing')
 
     if result.return_code != 0:
         print(f'\n!! failed to push image {args.registry}{image_name}')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,8 @@ dependencies = [
     "packaging >=21.3",
     "chardet >=3.0.2,<5.0.0",
     "tomli >=2.0.0,<3.0.0",
-    "pyotp >=2.9.0,<3.0.0"
+    "pyotp >=2.9.0,<3.0.0",
+    "progress >=1.6,<2.0"
 ]
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -178,6 +179,10 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = "setuptools_scm.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "progress.*"
 ignore_missing_imports = true
 
 [tool.coverage.run]

--- a/tests/unit/distributed/test_build.py
+++ b/tests/unit/distributed/test_build.py
@@ -301,7 +301,7 @@ def test_build(capsys: CaptureFixture, mocker: MockerFixture, tmp_path_factory: 
         capture = capsys.readouterr()
         assert capture.err == ''
         assert capture.out == (
-            f'built image {image_name}\n'
+            f'\nbuilt image {image_name}\n'
             f'\n!! failed to tag image {image_name} -> ghcr.io/biometria-se/{image_name}\n'
         )
 
@@ -335,7 +335,7 @@ def test_build(capsys: CaptureFixture, mocker: MockerFixture, tmp_path_factory: 
         capture = capsys.readouterr()
         assert capture.err == ''
         assert capture.out == (
-            f'built image {image_name}\n'
+            f'\nbuilt image {image_name}\n'
             f'tagged image {image_name} -> ghcr.io/biometria-se/{image_name}\n'
             f'\n!! failed to push image ghcr.io/biometria-se/{image_name}\n'
         )
@@ -358,7 +358,7 @@ def test_build(capsys: CaptureFixture, mocker: MockerFixture, tmp_path_factory: 
         capture = capsys.readouterr()
         assert capture.err == ''
         assert capture.out == (
-            f'built image {image_name}\n'
+            f'\nbuilt image {image_name}\n'
             f'tagged image {image_name} -> ghcr.io/biometria-se/{image_name}\n'
             f'pushed image ghcr.io/biometria-se/{image_name}\n'
         )

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1189,7 +1189,9 @@ def test_get_dependency_versions_pypi(mocker: MockerFixture, tmp_path_factory: T
         requirements_file.unlink()
         requirements_file.write_text('grizzly-loadtester[dev,mq]')
 
-        assert (('1.1.1', ['dev', 'mq'], ), '(unknown)',) == get_dependency_versions()
+        actual_dependency_versions = get_dependency_versions()
+
+        assert (('1.1.1', ['dev', 'mq'], ), '(unknown)',) == actual_dependency_versions
 
         capture = capsys.readouterr()
         assert capture.err == '!! unable to find locust version in "locust" specified in pypi for grizzly-loadtester 1.1.1\n'


### PR DESCRIPTION
also add a spinner when building image, so the user gets some kind of feedback.

fix in `get_dependency_versions` for determining the locust version.

closes Biometria-se/grizzly#284.