### PR TITLE
markdown classvar level problems

### DIFF
--- a/grizzly_cli/argparse/markdown.py
+++ b/grizzly_cli/argparse/markdown.py
@@ -1,8 +1,11 @@
-from typing import Any, List, Union, Sequence, Optional, Iterable, Tuple, Callable, Type, cast
-from typing_extensions import Self
+from __future__ import annotations
+from typing import TYPE_CHECKING, Any, List, Union, Sequence, Optional, Iterable, Tuple, Callable, Type, cast
 from types import MethodType
 from argparse import Action, SUPPRESS, ArgumentParser, Namespace, HelpFormatter
 from textwrap import fill as textwrap_fill
+
+if TYPE_CHECKING:  # pragma: no cover
+    from typing_extensions import Self
 
 
 __all__ = [

--- a/tests/unit/argparse/test___init__.py
+++ b/tests/unit/argparse/test___init__.py
@@ -157,7 +157,7 @@ optional arguments:
 
     def test_print_help_MarkdownFormatter(self, capsys: CaptureFixture, parsers: Tuple[ArgumentParser, ...]) -> None:
         parser, _, _ = parsers
-        parser.formatter_class = MarkdownFormatter
+        parser.formatter_class = MarkdownFormatter.factory(0)
 
         parser.print_help()
         capture = capsys.readouterr()

--- a/tests/unit/argparse/test_markdown.py
+++ b/tests/unit/argparse/test_markdown.py
@@ -215,9 +215,6 @@ you cannot belive it, it's another sentence.
 
         def test_format_help(self, capsys: CaptureFixture) -> None:
             formatter = MarkdownFormatter.factory(0)('test-prog')
-            import sys
-
-            print(f'{formatter.level=}', file=sys.stderr)
 
             action1 = argparse.Action(['-r', '--root'], dest='root', nargs=2, help='root argument')
             action2 = argparse.Action(['--root-const'], dest='root', nargs=0, default=True)
@@ -229,7 +226,6 @@ you cannot belive it, it's another sentence.
 
             format_help_text = formatter._current_section.format_help()
             assert capsys.readouterr().out == ''
-            print(f'{formatter.level=}', file=sys.stderr)
             assert format_help_text == '''
 
 ## Root section

--- a/tests/unit/argparse/test_markdown.py
+++ b/tests/unit/argparse/test_markdown.py
@@ -53,27 +53,27 @@ class TestMarkdownHelpAction:
         action.print_help(parser)
 
         assert print_help.call_count == 4
-        assert parser.formatter_class == MarkdownFormatter  # type: ignore
+        assert issubclass(parser.formatter_class, MarkdownFormatter)  # type: ignore
         assert parser._subparsers is not None
 
         _subparsers = getattr(parser, '_subparsers', None)
         assert _subparsers is not None
         for subparsers in _subparsers._group_actions:
             for name, subparser in subparsers.choices.items():
-                assert subparser.formatter_class == MarkdownFormatter  # type: ignore
+                assert issubclass(subparser.formatter_class, MarkdownFormatter)  # type: ignore
                 if name == 'a':
                     _subsubparsers = getattr(subparser, '_subparsers', None)
                     assert _subsubparsers is not None
                     for subsubparsers in _subsubparsers._group_actions:
                         for subsubparser in subsubparsers.choices.values():
-                            assert subsubparser.formatter_class == MarkdownFormatter
+                            assert issubclass(subsubparser.formatter_class, MarkdownFormatter)
 
     def test_print_help__format_help_markdown(self, mocker: MockerFixture) -> None:
         action = MarkdownHelpAction(['-t', '--test'])
         parser = argparse.ArgumentParser(description='test parser')
         parser._optionals.title = 'optional arguments'
 
-        formatter = MarkdownFormatter('test-prog')
+        formatter = MarkdownFormatter.factory(0)('test-prog')
 
         _get_formatter = mocker.patch.object(parser, '_get_formatter', side_effect=[formatter])
         add_text = mocker.patch.object(formatter, 'add_text', autospec=True)
@@ -96,14 +96,14 @@ class TestMarkdownHelpAction:
 
 class TestMarkdownFormatter:
     def test___init__(self) -> None:
-        formatter = MarkdownFormatter('test')
+        formatter = MarkdownFormatter.factory(0)('test')
         assert formatter._root_section is formatter._current_section
         assert formatter._root_section.parent is None
-        assert MarkdownFormatter.level == 0
+        assert formatter.level == 0
         assert formatter.current_level == 1
 
     def test__format_usage(self) -> None:
-        formatter = MarkdownFormatter('test')
+        formatter = MarkdownFormatter.factory(0)('test')
         usage = formatter._format_usage('test', None, None, 'a prefix')
         assert usage == '''
 ### Usage
@@ -133,7 +133,7 @@ test file
 '''
 
     def test_format_help(self) -> None:
-        formatter = MarkdownFormatter('test')
+        formatter = MarkdownFormatter.factory(0)('test')
         assert formatter.format_help() == ''
         assert formatter._root_section.heading == '# `test`'
 
@@ -160,7 +160,7 @@ you cannot belive it, it's another sentence.
 '''
 
     def test_start_section(self) -> None:
-        formatter = MarkdownFormatter('test-prog')
+        formatter = MarkdownFormatter.factory(0)('test-prog')
         assert formatter._root_section is formatter._current_section
 
         formatter.start_section('test-section-01')
@@ -172,7 +172,7 @@ you cannot belive it, it's another sentence.
         assert formatter._current_section.parent.items[0] == (formatter._current_section.format_help, [],)
 
     def test__format_action(self) -> None:
-        formatter = MarkdownFormatter('test-prog')
+        formatter = MarkdownFormatter.factory(0)('test-prog')
         action = argparse.Action(['-t', '--test'], dest='help', nargs=1, help='test argument')
 
         assert formatter._format_action(action) == ''
@@ -214,7 +214,10 @@ you cannot belive it, it's another sentence.
             assert len(section3.items) == 0
 
         def test_format_help(self, capsys: CaptureFixture) -> None:
-            formatter = MarkdownFormatter('test-prog')
+            formatter = MarkdownFormatter.factory(0)('test-prog')
+            import sys
+
+            print(f'{formatter.level=}', file=sys.stderr)
 
             action1 = argparse.Action(['-r', '--root'], dest='root', nargs=2, help='root argument')
             action2 = argparse.Action(['--root-const'], dest='root', nargs=0, default=True)
@@ -226,6 +229,7 @@ you cannot belive it, it's another sentence.
 
             format_help_text = formatter._current_section.format_help()
             assert capsys.readouterr().out == ''
+            print(f'{formatter.level=}', file=sys.stderr)
             assert format_help_text == '''
 
 ## Root section
@@ -249,6 +253,7 @@ you cannot belive it, it's another sentence.
             parent = formatter._current_section.parent
             formatter._current_section.parent = None
             formatter.end_section()
+            assert parent is not None
             formatter._current_section = parent
             format_help_text = formatter._current_section.format_help()
             assert capsys.readouterr().out == '\n'  # @TODO: whyyyyyyyyyy?!


### PR DESCRIPTION
the problem was found when unit test was executing in parallell.

make sure that `level` value isn't shared between all instances of `MarkdownFormatter` by using a factory method to create a new type. 

it still must be a classvar due to argparse wants a class type and not an instance, and we need to be able to control it before the class is instansiated.