### PR TITLE
support new grizzly step expressions

### DIFF
--- a/grizzly_cli/run.py
+++ b/grizzly_cli/run.py
@@ -312,7 +312,7 @@ def run(args: Arguments, run_func: Callable[[Arguments, Dict[str, Any], Dict[str
         run_arguments: Dict[str, List[str]] = {
             'master': [],
             'worker': [],
-            'common': ['--stop'],
+            'common': [],
         }
 
         if args.verbose:

--- a/grizzly_cli/utils.py
+++ b/grizzly_cli/utils.py
@@ -702,8 +702,8 @@ def distribution_of_users_per_scenario(args: Arguments, environ: Dict[str, Any])
                 match = re.match(r'repeat for "([^"]*)" iteration[s]?', step.name)
                 if match:
                     distribution[scenario.name].iterations = int(round(float(Template(match.group(1)).render(**variables)), 0))
-            elif (step.name.endswith(' users') or step.name.endswith(' user')) and step.keyword in ['Given', 'And']:
-                match = re.match(r'scenario is assigned "([^"]*)" user(s)?', step.name)
+            elif step.name.startswith('scenario is assigned') and step.keyword in ['Given', 'And']:
+                match = re.match(r'scenario is assigned "([^"]*)" user(s)?.*$', step.name)
                 if match:
                     scenario_user_count = int(round(float(Template(match.group(1)).render(**variables)), 0))
                     distribution[scenario.name].user_count = scenario_user_count
@@ -746,6 +746,7 @@ def distribution_of_users_per_scenario(args: Arguments, environ: Dict[str, Any])
         line = ['-' * 5, '-|-', '-' * 6, '|-', '-' * max_length_iterations, '|-', '-' * max_length_users, '|-', '-' * max_length_description, '-|']
         if not use_weights:
             line = line[:1] + line[3:]
+            line[0] = f'{line[0]}-'
 
         if max_length_errors > 0:
             line += ['-' * (max_length_errors + 1), '-|']
@@ -785,7 +786,7 @@ def distribution_of_users_per_scenario(args: Arguments, environ: Dict[str, Any])
     if len(errors) < 1:
         max_length_errors = 0
 
-    row_format = ['{:5}', '   {:>6d}', '  {:>{}}', '  {:>{}}', '  {:<{}}']
+    row_format = ['{:5} ', '  {:>6d}', '  {:>{}}', '  {:>{}}', '  {:<{}}']
     if not use_weights:
         row_format.pop(1)
 
@@ -824,7 +825,7 @@ def distribution_of_users_per_scenario(args: Arguments, environ: Dict[str, Any])
         'description', max_length_description,
     ]
 
-    header_row_format = ['{:5}', '   {:>6}', '  {:>{}}', '  {:>{}}', '  {:<{}}']
+    header_row_format = ['{:5} ', '  {:>6}', '  {:>{}}', '  {:>{}}', '  {:<{}}']
     if not use_weights:
         header_row_format.pop(1)
         header_row_args.pop(1)

--- a/grizzly_cli/utils.py
+++ b/grizzly_cli/utils.py
@@ -672,7 +672,8 @@ def distribution_of_users_per_scenario(args: Arguments, environ: Dict[str, Any])
                 iterations=None,
             )
 
-    scenario_user_count = 0
+    scenario_user_count_total: Optional[int] = None
+    use_weights = True
 
     for index, scenario in enumerate(grizzly_cli.SCENARIOS):
         if len(scenario.steps) < 1:
@@ -685,7 +686,11 @@ def distribution_of_users_per_scenario(args: Arguments, environ: Dict[str, Any])
                 if (step.name.endswith(' users') or step.name.endswith(' user')) and step.keyword == 'Given':
                     match = re.match(r'"([^"]*)" user(s)?', step.name)
                     if match:
-                        scenario_user_count = int(round(float(Template(match.group(1)).render(**variables)), 0))
+                        scenario_user_count_total = int(round(float(Template(match.group(1)).render(**variables)), 0))
+
+        if scenario_user_count_total is None:
+            use_weights = False
+            scenario_user_count_total = 0
 
         for step in scenario.steps:
             if step.name.startswith('a user of type'):
@@ -697,9 +702,16 @@ def distribution_of_users_per_scenario(args: Arguments, environ: Dict[str, Any])
                 match = re.match(r'repeat for "([^"]*)" iteration[s]?', step.name)
                 if match:
                     distribution[scenario.name].iterations = int(round(float(Template(match.group(1)).render(**variables)), 0))
+            elif (step.name.endswith(' users') or step.name.endswith(' user')) and step.keyword in ['Given', 'And']:
+                match = re.match(r'scenario is assigned "([^"]*)" user(s)?', step.name)
+                if match:
+                    scenario_user_count = int(round(float(Template(match.group(1)).render(**variables)), 0))
+                    distribution[scenario.name].user_count = scenario_user_count
+                    scenario_user_count_total += scenario_user_count
 
     scenario_count = len(distribution.keys())
-    if scenario_count > scenario_user_count:
+    assert scenario_user_count_total is not None
+    if scenario_count > scenario_user_count_total:
         raise ValueError(f'grizzly needs at least {scenario_count} users to run this feature')
 
     total_weight = 0
@@ -711,26 +723,30 @@ def distribution_of_users_per_scenario(args: Arguments, environ: Dict[str, Any])
         total_weight += scenario.weight
         total_iterations += scenario.iterations
 
-    for scenario in distribution.values():
-        scenario.user_count = ceil(scenario_user_count * (scenario.weight / total_weight))
+    if use_weights:
+        for scenario in distribution.values():
+            scenario.user_count = ceil(scenario_user_count_total * (scenario.weight / total_weight))
 
-    # smooth assigned user count based on weight, so that the sum of scenario.user_count == total_user_count
-    total_user_count = sum([scenario.user_count for scenario in distribution.values()])
-    user_overflow = total_user_count - scenario_user_count
+        # smooth assigned user count based on weight, so that the sum of scenario.user_count == total_user_count
+        total_user_count = sum([scenario.user_count for scenario in distribution.values()])
+        user_overflow = total_user_count - scenario_user_count_total
 
-    while user_overflow > 0:
-        for scenario in dict(sorted(distribution.items(), key=lambda d: d[1].user_count, reverse=True)).values():
-            if scenario.user_count <= 1:
-                continue
+        while user_overflow > 0:
+            for scenario in dict(sorted(distribution.items(), key=lambda d: d[1].user_count, reverse=True)).values():
+                if scenario.user_count <= 1:
+                    continue
 
-            scenario.user_count -= 1
-            user_overflow -= 1
+                scenario.user_count -= 1
+                user_overflow -= 1
 
-            if user_overflow < 1:
-                break
+                if user_overflow < 1:
+                    break
 
     def print_table_lines(max_length_iterations: int, max_length_users: int, max_length_description: int, max_length_errors: int) -> None:
         line = ['-' * 5, '-|-', '-' * 6, '|-', '-' * max_length_iterations, '|-', '-' * max_length_users, '|-', '-' * max_length_description, '-|']
+        if not use_weights:
+            line = line[:1] + line[3:]
+
         if max_length_errors > 0:
             line += ['-' * (max_length_errors + 1), '-|']
         logger.info(''.join(line))
@@ -741,7 +757,7 @@ def distribution_of_users_per_scenario(args: Arguments, environ: Dict[str, Any])
     max_length_users = len('#user')
     max_length_errors = len('errors')
 
-    logger.info(f'\nfeature file {args.file} will execute in total {total_iterations} iterations\n')
+    logger.info(f'\nfeature file {args.file} will execute in total {total_iterations} iterations divided on {len(grizzly_cli.SCENARIOS)} scenarios\n')
 
     errors: Dict[str, List[str]] = {}
 
@@ -769,9 +785,15 @@ def distribution_of_users_per_scenario(args: Arguments, environ: Dict[str, Any])
     if len(errors) < 1:
         max_length_errors = 0
 
+    row_format = ['{:5}', '   {:>6d}', '  {:>{}}', '  {:>{}}', '  {:<{}}']
+    if not use_weights:
+        row_format.pop(1)
+
+    if len(errors) > 0:
+        row_format.append('   {}')
+
     for scenario in distribution.values():
-        row_format = '{:5}   {:>6d}  {:>{}}  {:>{}}  {:<{}}'
-        row_format_args: Tuple[Any, ...] = (
+        row_format_args: List[Any] = [
             scenario.identifier,
             scenario.weight,
             scenario.iterations,
@@ -780,40 +802,47 @@ def distribution_of_users_per_scenario(args: Arguments, environ: Dict[str, Any])
             max_length_users,
             scenario.name,
             max_length_description,
-        )
+        ]
+
+        # remove weights column
+        if not use_weights:
+            row_format_args.pop(1)
 
         if len(errors) > 0:
-            row_format += '   {}'
-            row_format_args += (
+            row_format_args.append(
                 ', '.join(errors.get(scenario.name, [])),
             )
 
-        rows.append(row_format.format(*row_format_args))
+        rows.append(''.join(row_format).format(*row_format_args))
 
     logger.info('each scenario will execute accordingly:\n')
-    header_row_format = '{:5}   {:>6}  {:>{}}  {:>{}}  {:<{}}'
-    header_row_args: Tuple[Any, ...] = (
+    header_row_args: List[Any] = [
         'ident',
         'weight',
         '#iter', max_length_iterations,
         '#user', max_length_users,
         'description', max_length_description,
-    )
+    ]
+
+    header_row_format = ['{:5}', '   {:>6}', '  {:>{}}', '  {:>{}}', '  {:<{}}']
+    if not use_weights:
+        header_row_format.pop(1)
+        header_row_args.pop(1)
 
     if len(errors) > 0:
-        header_row_format += '   {}'
-        header_row_args += (
-            'errors',
-        )
+        header_row_format.append('   {}')
+        header_row_args.append('errors')
 
-    logger.info(header_row_format.format(*header_row_args))
+    logger.info(''.join(header_row_format).format(*header_row_args))
     print_table_lines(max_length_iterations, max_length_users, max_length_description, max_length_errors)
     for row in rows:
         logger.info(row)
     print_table_lines(max_length_iterations, max_length_users, max_length_description, max_length_errors)
 
     if len(errors) > 0:
-        arrow_width = len('ident') + 2 + len('weight') + 2 + max_length_iterations + 2 + max_length_users + 2 + max_length_description + 2
+        arrow_width = len('ident') + 2 + max_length_iterations + 2 + max_length_users + 2 + max_length_description + 2
+        if use_weights:
+            arrow_width += len('weight') + 2
         message = f'''{" "* (1 + arrow_width)}^
 +{"-" * arrow_width}+
 |

--- a/grizzly_cli/utils.py
+++ b/grizzly_cli/utils.py
@@ -702,12 +702,14 @@ def distribution_of_users_per_scenario(args: Arguments, environ: Dict[str, Any])
                 match = re.match(r'repeat for "([^"]*)" iteration[s]?', step.name)
                 if match:
                     distribution[scenario.name].iterations = int(round(float(Template(match.group(1)).render(**variables)), 0))
-            elif step.name.startswith('scenario is assigned') and step.keyword in ['Given', 'And']:
-                match = re.match(r'scenario is assigned "([^"]*)" user(s)?.*$', step.name)
+            elif any([pattern in step.name for pattern in ['users of type', 'user of type']]):
+                match = re.match(r'"([^"]*)" user[s]? of type "([^"]*)".*', step.name)
                 if match:
                     scenario_user_count = int(round(float(Template(match.group(1)).render(**variables)), 0))
-                    distribution[scenario.name].user_count = scenario_user_count
                     scenario_user_count_total += scenario_user_count
+
+                    distribution[scenario.name].user_count = scenario_user_count
+                    distribution[scenario.name].user = match.group(2)
 
     scenario_count = len(distribution.keys())
     assert scenario_user_count_total is not None

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -321,6 +321,9 @@ bar = foo
 
         # --dump output.feature
         feature_file.write_text("""Feature: a feature
+    Background: common
+        Given a common step
+
     Scenario: first
         Given a variable with value "{{foo * 0.25 | int }}" and another value " {{ bar |int + 12}}"
         And a variable with value "{{ hello }}"
@@ -336,6 +339,9 @@ bar = foo
 """)
         feature_file_2 = execution_context / 'second.feature'
         feature_file_2.write_text("""Feature: a second feature
+    Background: common
+        Given a common step
+
     Scenario: second
         Given a variable with value "{{ foobar }}"
         Then run a bloody test
@@ -361,6 +367,9 @@ bar = foo
 
         output_file = execution_context / 'output.feature'
         assert output_file.read_text() == """Feature: a feature
+    Background: common
+        Given a common step
+
     Scenario: first
         Given a variable with value "{{foo * 0.25 | int }}" and another value " {{ bar |int + 12}}"
         And a variable with value "{{ hello }}"
@@ -382,9 +391,15 @@ bar = foo
 
     Scenario: second
         {% scenario "second", feature="./second.feature" %}
+
+    # Scenario: third
+    #     {% scenario "second", feature="./second.feature" %}
 """)
         feature_file_2 = execution_context / 'second.feature'
         feature_file_2.write_text("""Feature: a second feature
+    Background: common
+        Given a common step
+
     Scenario: second
         Given a variable with value "{{ foobar }}"
         Then run a bloody test
@@ -419,6 +434,9 @@ bar = foo
     Scenario: second
         Given a variable with value "{{ foobar }}"
         Then run a bloody test
+
+    # Scenario: third
+    #     {% scenario "second", feature="./second.feature" %}
 """
         assert feature_file.read_text() == """Feature: a feature
     Scenario: first
@@ -426,6 +444,9 @@ bar = foo
 
     Scenario: second
         {% scenario "second", feature="./second.feature" %}
+
+    # Scenario: third
+    #     {% scenario "second", feature="./second.feature" %}
 """
     finally:
         tmp_path_factory._basetemp = original_tmp_path

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -394,6 +394,9 @@ bar = foo
 
     # Scenario: third
     #     {% scenario "second", feature="./second.feature" %}
+
+    Scenario: third
+        {% scenario "third", feature="./second.feature" %}
 """)
         feature_file_2 = execution_context / 'second.feature'
         feature_file_2.write_text("""Feature: a second feature
@@ -403,9 +406,20 @@ bar = foo
     Scenario: second
         Given a variable with value "{{ foobar }}"
         Then run a bloody test
+            \"\"\"
+            with step text
+            that spans
+            more than
+            one line
+            \"\"\"
 
     Scenario: third
         Given a variable with value "{{ value }}"
+        Then run a bloody test, with table
+          | hello | world |
+          | foo   | bar   |
+          | bar   |       |
+          |       | foo   |
 """)
 
         arguments = parser.parse_args([
@@ -434,9 +448,23 @@ bar = foo
     Scenario: second
         Given a variable with value "{{ foobar }}"
         Then run a bloody test
+            \"\"\"
+            with step text
+            that spans
+            more than
+            one line
+            \"\"\"
 
     # Scenario: third
     #     {% scenario "second", feature="./second.feature" %}
+
+    Scenario: third
+        Given a variable with value "{{ value }}"
+        Then run a bloody test, with table
+            | hello | world |
+            | foo | bar |
+            | bar |  |
+            |  | foo |
 """
         assert feature_file.read_text() == """Feature: a feature
     Scenario: first
@@ -447,6 +475,9 @@ bar = foo
 
     # Scenario: third
     #     {% scenario "second", feature="./second.feature" %}
+
+    Scenario: third
+        {% scenario "third", feature="./second.feature" %}
 """
     finally:
         tmp_path_factory._basetemp = original_tmp_path

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -81,7 +81,7 @@ bar = foo
             }, {
                 'master': [],
                 'worker': [],
-                'common': ['--stop', '--verbose', '--no-logcapture', '--no-capture', '--no-capture-stderr'],
+                'common': ['--verbose', '--no-logcapture', '--no-capture', '--no-capture-stderr'],
             }
         )
         distributed_mock.reset_mock()
@@ -127,7 +127,7 @@ bar = foo
             }, {
                 'master': [],
                 'worker': [],
-                'common': ['--stop'],
+                'common': [],
             }
         )
         local_mock.reset_mock()
@@ -162,7 +162,7 @@ bar = foo
             }, {
                 'master': [],
                 'worker': [],
-                'common': ['--stop'],
+                'common': [],
             }
         )
         local_mock.reset_mock()
@@ -195,7 +195,7 @@ bar = foo
             }, {
                 'master': [],
                 'worker': [],
-                'common': ['--stop'],
+                'common': [],
             }
         )
         local_mock.reset_mock()
@@ -225,7 +225,7 @@ bar = foo
             }, {
                 'master': [],
                 'worker': [],
-                'common': ['--stop', '-Dcsv-prefix="test test"', '-Dcsv-interval=20'],
+                'common': ['-Dcsv-prefix="test test"', '-Dcsv-interval=20'],
             }
         )
         local_mock.reset_mock()
@@ -260,7 +260,7 @@ bar = foo
             }, {
                 'master': [],
                 'worker': [],
-                'common': ['--stop', '-Dcsv-prefix="this_feature_is_testing_something_20221206T130113"', '-Dcsv-interval=20', '-Dcsv-flush-interval=60'],
+                'common': ['-Dcsv-prefix="this_feature_is_testing_something_20221206T130113"', '-Dcsv-interval=20', '-Dcsv-flush-interval=60'],
             }
         )
         distributed_mock.reset_mock()
@@ -292,7 +292,7 @@ bar = foo
             }, {
                 'master': [],
                 'worker': [],
-                'common': ['--stop'],
+                'common': [],
             }
         )
         distributed_mock.reset_mock()

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -971,8 +971,7 @@ def test_distribution_of_users_per_scenario_no_weights(capsys: CaptureFixture, m
             'scenario-0',
             background_steps,
             [
-                'Given a user of type "RestApi" load testing "https://localhost"',
-                'And scenario is assigned "{{ ((((max_users * 0.7) - 0.5) | int) or 1) if max_users is defined else 1 }}" users',
+                'Given "{{ ((((max_users * 0.7) - 0.5) | int) or 1) if max_users is defined else 1 }}" users of type "RestApi" load testing "https://localhost"',
                 'And repeat for "{{ (leveranser | int) + ((((leveranser * 0.7) + 0.5) | int) or 1) + ((((leveranser * 0.3) + 0.5) | int) or 1) }}" iterations',
             ],
         ),
@@ -980,8 +979,7 @@ def test_distribution_of_users_per_scenario_no_weights(capsys: CaptureFixture, m
             'scenario-1',
             background_steps,
             [
-                'Given a user of type "RestApi" load testing "https://localhost"',
-                'And scenario is assigned "{{ ((((max_users_undefined * 0.3) - 0.5) | int) or 1) if max_users_undefined is defined else 1 }}" users with tag "foo"',
+                'Given "{{ ((((max_users_undefined * 0.3) - 0.5) | int) or 1) if max_users_undefined is defined else 1 }}" user of type "RestApi" load testing "https://localhost"',
                 'And repeat for "{{ ((leveranser * 0.3) + 0.5) | int }}" iterations',
             ]
         ),
@@ -997,7 +995,6 @@ def test_distribution_of_users_per_scenario_no_weights(capsys: CaptureFixture, m
     capture = capsys.readouterr()
 
     assert capture.out == ''
-    print(capture.err)
     assert capture.err == ''.join([
         '\n',
         'feature file integration.feature will execute in total 23 iterations divided on 2 scenarios\n',

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -479,7 +479,7 @@ def test_distribution_of_users_per_scenario(capsys: CaptureFixture, mocker: Mock
     assert capture.out == ''
     expected_lines = [
         '\n',
-        'feature file test.feature will execute in total 2 iterations\n',
+        'feature file test.feature will execute in total 2 iterations divided on 2 scenarios\n',
         '\n',
         'each scenario will execute accordingly:\n',
         '\n',
@@ -565,7 +565,7 @@ def test_distribution_of_users_per_scenario(capsys: CaptureFixture, mocker: Mock
     assert capture.out == ''
     assert capture.err == ''.join([
         '\n',
-        'feature file test.feature will execute in total 55 iterations\n'
+        'feature file test.feature will execute in total 55 iterations divided on 2 scenarios\n'
         '\n',
         'each scenario will execute accordingly:\n',
         '\n',
@@ -633,7 +633,7 @@ def test_distribution_of_users_per_scenario(capsys: CaptureFixture, mocker: Mock
     assert capture.out == ''
     assert capture.err == ''.join([
         '\n',
-        'feature file integration.feature will execute in total 1260 iterations\n'
+        'feature file integration.feature will execute in total 1260 iterations divided on 3 scenarios\n'
         '\n',
         'each scenario will execute accordingly:\n',
         '\n',
@@ -667,7 +667,7 @@ def test_distribution_of_users_per_scenario(capsys: CaptureFixture, mocker: Mock
     assert capture.out == ''
     assert capture.err == ''.join([
         '\n',
-        'feature file integration.feature will execute in total 1 iterations\n'
+        'feature file integration.feature will execute in total 1 iterations divided on 1 scenarios\n'
         '\n',
         'each scenario will execute accordingly:\n',
         '\n',
@@ -728,7 +728,7 @@ def test_distribution_of_users_per_scenario(capsys: CaptureFixture, mocker: Mock
     assert capture.out == ''
     assert capture.err == ''.join([
         '\n',
-        'feature file integration.feature will execute in total 20 iterations\n'
+        'feature file integration.feature will execute in total 20 iterations divided on 4 scenarios\n'
         '\n',
         'each scenario will execute accordingly:\n',
         '\n',
@@ -751,7 +751,7 @@ def test_distribution_of_users_per_scenario(capsys: CaptureFixture, mocker: Mock
         6, 13,
         ''.join([
             '\n',
-            'feature file integration.feature will execute in total 28 iterations\n'
+            'feature file integration.feature will execute in total 28 iterations divided on 7 scenarios\n'
             '\n',
             'each scenario will execute accordingly:\n',
             '\n',
@@ -772,7 +772,7 @@ def test_distribution_of_users_per_scenario(capsys: CaptureFixture, mocker: Mock
         12, 20,
         ''.join([
             '\n',
-            'feature file integration.feature will execute in total 43 iterations\n',
+            'feature file integration.feature will execute in total 43 iterations divided on 7 scenarios\n',
             '\n',
             'each scenario will execute accordingly:\n',
             '\n',
@@ -793,7 +793,7 @@ def test_distribution_of_users_per_scenario(capsys: CaptureFixture, mocker: Mock
         18, 31,
         ''.join([
             '\n',
-            'feature file integration.feature will execute in total 66 iterations\n',
+            'feature file integration.feature will execute in total 66 iterations divided on 7 scenarios\n',
             '\n',
             'each scenario will execute accordingly:\n',
             '\n',
@@ -814,7 +814,7 @@ def test_distribution_of_users_per_scenario(capsys: CaptureFixture, mocker: Mock
         24, 49,
         ''.join([
             '\n',
-            'feature file integration.feature will execute in total 105 iterations\n',
+            'feature file integration.feature will execute in total 105 iterations divided on 7 scenarios\n',
             '\n',
             'each scenario will execute accordingly:\n',
             '\n',
@@ -835,7 +835,7 @@ def test_distribution_of_users_per_scenario(capsys: CaptureFixture, mocker: Mock
         30, 58,
         ''.join([
             '\n',
-            'feature file integration.feature will execute in total 124 iterations\n',
+            'feature file integration.feature will execute in total 124 iterations divided on 7 scenarios\n',
             '\n',
             'each scenario will execute accordingly:\n',
             '\n',
@@ -856,7 +856,7 @@ def test_distribution_of_users_per_scenario(capsys: CaptureFixture, mocker: Mock
         30, 21000,
         ''.join([
             '\n',
-            'feature file integration.feature will execute in total 44940 iterations\n',
+            'feature file integration.feature will execute in total 44940 iterations divided on 7 scenarios\n',
             '\n',
             'each scenario will execute accordingly:\n',
             '\n',


### PR DESCRIPTION
support for new `Given ".." users of type...` step in grizzly. 

include step text and table when rendering `{% scenario ... %}`.

remove `--stop`, so behave doesn't stop on first error.