### PR TITLE
implementation of `--dry-run` in `run` command

### DIFF
--- a/grizzly_cli/run.py
+++ b/grizzly_cli/run.py
@@ -222,6 +222,12 @@ def create_parser(sub_parser: ArgumentSubParser, parent: str) -> None:
         ),
     )
     run_parser.add_argument(
+        '--dry-run',
+        action='store_true',
+        required=False,
+        help='Will setup and run anything up until when locust should start. Useful for debugging feature files when developing new tests',
+    )
+    run_parser.add_argument(
         'file',
         nargs='+',
         type=BashCompletionTypes.File('*.feature'),
@@ -306,6 +312,9 @@ def run(args: Arguments, run_func: Callable[[Arguments, Dict[str, Any], Dict[str
         if args.environment_file is not None:
             environment_file = os.path.realpath(args.environment_file)
             environ.update({'GRIZZLY_CONFIGURATION_FILE': environment_file})
+
+        if args.dry_run:
+            environ.update({'GRIZZLY_DRY_RUN': 'true'})
 
         if args.log_dir is not None:
             environ.update({'GRIZZLY_LOG_DIR': args.log_dir})

--- a/tests/unit/argparse/bashcompletion/test__init__.py
+++ b/tests/unit/argparse/bashcompletion/test__init__.py
@@ -238,23 +238,26 @@ class TestBashCompleteAction:
                 'grizzly-cli local run ',
                 (
                     '-h\n--help\n--verbose\n-T\n--testdata-variable\n-y\n--yes\n-e\n--environment-file\n--csv-prefix\n--csv-interval\n'
-                    '--csv-flush-interval\n-l\n--log-file\n--log-dir\n--dump\ntest.feature\ntest-dir'
+                    '--csv-flush-interval\n-l\n--log-file\n--log-dir\n--dump\n--dry-run\ntest.feature\ntest-dir'
                 ),
             ),
             (
                 'grizzly-cli local run -',
                 (
                     '-h\n--help\n--verbose\n-T\n--testdata-variable\n-y\n--yes\n-e\n--environment-file\n--csv-prefix\n--csv-interval\n--csv-flush-interval\n-l\n--log-file\n'
-                    '--log-dir\n--dump'
+                    '--log-dir\n--dump\n--dry-run'
                 ),
             ),
             (
                 'grizzly-cli local run --',
-                '--help\n--verbose\n--testdata-variable\n--yes\n--environment-file\n--csv-prefix\n--csv-interval\n--csv-flush-interval\n--log-file\n--log-dir\n--dump',
+                '--help\n--verbose\n--testdata-variable\n--yes\n--environment-file\n--csv-prefix\n--csv-interval\n--csv-flush-interval\n--log-file\n--log-dir\n--dump\n--dry-run',
             ),
             (
                 'grizzly-cli local run --yes',
-                '-h\n--help\n--verbose\n-T\n--testdata-variable\n-e\n--environment-file\n--csv-prefix\n--csv-interval\n--csv-flush-interval\n-l\n--log-file\n--log-dir\n--dump',
+                (
+                    '-h\n--help\n--verbose\n-T\n--testdata-variable\n-e\n--environment-file\n--csv-prefix\n--csv-interval\n--csv-flush-interval\n-l\n--log-file\n--log-dir\n'
+                    '--dump\n--dry-run'
+                ),
             ),
             ('grizzly-cli local run --help --yes', ''),
             ('grizzly-cli local run --yes -T', ''),
@@ -262,7 +265,7 @@ class TestBashCompleteAction:
                 'grizzly-cli local run --yes -T key=value',
                 (
                     '-h\n--help\n--verbose\n-T\n--testdata-variable\n-e\n--environment-file\n--csv-prefix\n--csv-interval\n'
-                    '--csv-flush-interval\n-l\n--log-file\n--log-dir\n--dump\ntest.feature\ntest-dir'
+                    '--csv-flush-interval\n-l\n--log-file\n--log-dir\n--dump\n--dry-run\ntest.feature\ntest-dir'
                 ),
             ),
             ('grizzly-cli local run --yes -T key=value --env', '--environment-file'),
@@ -271,18 +274,21 @@ class TestBashCompleteAction:
             ('grizzly-cli local run --yes -T key=value --environment-file test-', 'test-dir'),
             (
                 'grizzly-cli local run --yes -T key=value --environment-file test-dir',
-                '-h\n--help\n--verbose\n-T\n--testdata-variable\n--csv-prefix\n--csv-interval\n--csv-flush-interval\n-l\n--log-file\n--log-dir\n--dump',
+                '-h\n--help\n--verbose\n-T\n--testdata-variable\n--csv-prefix\n--csv-interval\n--csv-flush-interval\n-l\n--log-file\n--log-dir\n--dump\n--dry-run',
             ),
             ('grizzly-cli local run --yes -T key=value --environment-file test.', 'test.yaml'),
             (
                 'grizzly-cli local run --yes -T key=value --environment-file test.yaml',
-                '-h\n--help\n--verbose\n-T\n--testdata-variable\n--csv-prefix\n--csv-interval\n--csv-flush-interval\n-l\n--log-file\n--log-dir\n--dump',
+                '-h\n--help\n--verbose\n-T\n--testdata-variable\n--csv-prefix\n--csv-interval\n--csv-flush-interval\n-l\n--log-file\n--log-dir\n--dump\n--dry-run',
             ),
             ('grizzly-cli local run --yes -T key=value --environment-file test.yaml --test', '--testdata-variable'),
             ('grizzly-cli local run --yes -T key=value --environment-file test.yaml --testdata-variable', ''),
             (
                 'grizzly-cli local run --yes -T key=value --environment-file test.yaml --testdata-variable key=value',
-                '-h\n--help\n--verbose\n-T\n--testdata-variable\n--csv-prefix\n--csv-interval\n--csv-flush-interval\n-l\n--log-file\n--log-dir\n--dump\ntest.feature\ntest-dir',
+                (
+                    '-h\n--help\n--verbose\n-T\n--testdata-variable\n--csv-prefix\n--csv-interval\n--csv-flush-interval\n-l\n--log-file\n--log-dir\n--dump\n--dry-run\n'
+                    'test.feature\ntest-dir'
+                ),
             ),
             ('grizzly-cli local run --yes -T key=value --environment-file test.yaml --testdata-variable key=value test', 'test.feature\ntest-dir'),
             ('grizzly-cli local run --yes -T key=value --environment-file test.yaml --testdata-variable key=value test-dir', 'test-dir'),
@@ -293,7 +299,7 @@ class TestBashCompleteAction:
             ),
             (
                 f'grizzly-cli local run --yes -T key=value --environment-file test.yaml --testdata-variable key=value test-dir{path.sep}test.feature',
-                '-h\n--help\n--verbose\n-T\n--testdata-variable\n--csv-prefix\n--csv-interval\n--csv-flush-interval\n-l\n--log-file\n--log-dir\n--dump',
+                '-h\n--help\n--verbose\n-T\n--testdata-variable\n--csv-prefix\n--csv-interval\n--csv-flush-interval\n-l\n--log-file\n--log-dir\n--dump\n--dry-run',
             ),
             ('grizzly-cli local run --yes -T key=value --environment-file test.yaml --testdata-variable key=value test.fe', 'test.feature'),
             ('grizzly-cli local run --yes -T key=value --environment-file test.yaml --testdata-variable key=value --help', ''),
@@ -346,23 +352,26 @@ class TestBashCompleteAction:
                 'grizzly-cli dist run ',
                 (
                     '-h\n--help\n--verbose\n-T\n--testdata-variable\n-y\n--yes\n-e\n--environment-file\n'
-                    '--csv-prefix\n--csv-interval\n--csv-flush-interval\n-l\n--log-file\n--log-dir\n--dump\ntest.feature\ntest-dir'
+                    '--csv-prefix\n--csv-interval\n--csv-flush-interval\n-l\n--log-file\n--log-dir\n--dump\n--dry-run\ntest.feature\ntest-dir'
                 ),
             ),
             (
                 'grizzly-cli dist run -',
                 (
                     '-h\n--help\n--verbose\n-T\n--testdata-variable\n-y\n--yes\n-e\n--environment-file\n--csv-prefix\n--csv-interval\n--csv-flush-interval\n-l\n'
-                    '--log-file\n--log-dir\n--dump'
+                    '--log-file\n--log-dir\n--dump\n--dry-run'
                 ),
             ),
             (
                 'grizzly-cli dist run --',
-                '--help\n--verbose\n--testdata-variable\n--yes\n--environment-file\n--csv-prefix\n--csv-interval\n--csv-flush-interval\n--log-file\n--log-dir\n--dump',
+                '--help\n--verbose\n--testdata-variable\n--yes\n--environment-file\n--csv-prefix\n--csv-interval\n--csv-flush-interval\n--log-file\n--log-dir\n--dump\n--dry-run',
             ),
             (
                 'grizzly-cli dist run --yes',
-                '-h\n--help\n--verbose\n-T\n--testdata-variable\n-e\n--environment-file\n--csv-prefix\n--csv-interval\n--csv-flush-interval\n-l\n--log-file\n--log-dir\n--dump',
+                (
+                    '-h\n--help\n--verbose\n-T\n--testdata-variable\n-e\n--environment-file\n--csv-prefix\n--csv-interval\n--csv-flush-interval\n'
+                    '-l\n--log-file\n--log-dir\n--dump\n--dry-run'
+                )
             ),
             ('grizzly-cli dist run --help --yes', ''),
             ('grizzly-cli dist run --yes -T', ''),
@@ -370,7 +379,7 @@ class TestBashCompleteAction:
                 'grizzly-cli dist run --yes -T key=value',
                 (
                     '-h\n--help\n--verbose\n-T\n--testdata-variable\n-e\n--environment-file\n--csv-prefix\n--csv-interval\n'
-                    '--csv-flush-interval\n-l\n--log-file\n--log-dir\n--dump\ntest.feature\ntest-dir'
+                    '--csv-flush-interval\n-l\n--log-file\n--log-dir\n--dump\n--dry-run\ntest.feature\ntest-dir'
                 ),
             ),
             ('grizzly-cli dist run --yes -T key=value --env', '--environment-file'),
@@ -379,18 +388,21 @@ class TestBashCompleteAction:
             ('grizzly-cli dist run --yes -T key=value --environment-file test-', 'test-dir'),
             (
                 'grizzly-cli dist run --yes -T key=value --environment-file test-dir',
-                '-h\n--help\n--verbose\n-T\n--testdata-variable\n--csv-prefix\n--csv-interval\n--csv-flush-interval\n-l\n--log-file\n--log-dir\n--dump',
+                '-h\n--help\n--verbose\n-T\n--testdata-variable\n--csv-prefix\n--csv-interval\n--csv-flush-interval\n-l\n--log-file\n--log-dir\n--dump\n--dry-run',
             ),
             ('grizzly-cli dist run --yes -T key=value --environment-file test.', 'test.yaml'),
             (
                 'grizzly-cli dist run --yes -T key=value --environment-file test.yaml',
-                '-h\n--help\n--verbose\n-T\n--testdata-variable\n--csv-prefix\n--csv-interval\n--csv-flush-interval\n-l\n--log-file\n--log-dir\n--dump',
+                '-h\n--help\n--verbose\n-T\n--testdata-variable\n--csv-prefix\n--csv-interval\n--csv-flush-interval\n-l\n--log-file\n--log-dir\n--dump\n--dry-run',
             ),
             ('grizzly-cli dist run --yes -T key=value --environment-file test.yaml --test', '--testdata-variable'),
             ('grizzly-cli dist run --yes -T key=value --environment-file test.yaml --testdata-variable', ''),
             (
                 'grizzly-cli dist run --yes -T key=value --environment-file test.yaml --testdata-variable key=value',
-                '-h\n--help\n--verbose\n-T\n--testdata-variable\n--csv-prefix\n--csv-interval\n--csv-flush-interval\ntest.feature\ntest-dir\n-l\n--log-file\n--log-dir\n--dump',
+                (
+                    '-h\n--help\n--verbose\n-T\n--testdata-variable\n--csv-prefix\n--csv-interval\n--csv-flush-interval\ntest.feature\ntest-dir\n-l\n--log-file\n'
+                    '--log-dir\n--dump\n--dry-run'
+                ),
             ),
             ('grizzly-cli dist run --yes -T key=value --environment-file test.yaml --testdata-variable key=value test', 'test.feature\ntest-dir'),
             ('grizzly-cli dist run --yes -T key=value --environment-file test.yaml --testdata-variable key=value test.fe', 'test.feature'),

--- a/tests/unit/test___main__.py
+++ b/tests/unit/test___main__.py
@@ -136,6 +136,7 @@ def test__create_parser() -> None:
             '--csv-prefix', '--csv-interval', '--csv-flush-interval',
             '-l', '--log-dir', '--log-file',
             '--dump',
+            '--dry-run',
         ])
         assert sorted([action.dest for action in run_parser._actions if len(action.option_strings) == 0]) == ['file']
 


### PR DESCRIPTION
support for new grizzly feature that would "dry run" a feature-file to catch errors as soon as possible.