### PR TITLE
remove top-level version element in compose.yaml

### DIFF
--- a/grizzly_cli/static/compose.yaml
+++ b/grizzly_cli/static/compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   master:
     hostname: master

--- a/tests/e2e/test_run.py
+++ b/tests/e2e/test_run.py
@@ -152,6 +152,8 @@ def test_e2e_run_example(e2e_fixture: End2EndFixture) -> None:
             assert "received from CLIENT" in result
             assert "AtomicCustomVariable.foobar='foobar'" in result
 
+            assert 'compose.yaml: `version` is obsolete' not in result
+
             datestamp = datetime.now().astimezone().strftime('%Y%m%dT')
 
             csv_file_exceptions = list(example_root.glob('*_exceptions.csv'))


### PR DESCRIPTION
starting from docker compose 2.25.0 it will give a warning if the element i present:
```
time="2024-03-27T14:34:41+01:00" level=warning msg=".../grizzly_cli/static/compose.yaml: `version` is obsolete"
```

the element has been ignored since V2.