### PR TITLE
allow nested `{% scenario .. %}` tags and special tag variables (`{$ .. $}`)

### DIFF
--- a/grizzly_cli/run.py
+++ b/grizzly_cli/run.py
@@ -47,12 +47,53 @@ class OnlyScenarioTag(StandaloneTag):
             feature_file = (self.environment.feature_file.parent / feature).resolve()
 
         feature_content = feature_file.read_text()
+        # <!-- sub-render included scenario
+        errors_unused: Set[str] = set()
+        errors_undeclared: Set[str] = set()
+
+        # tag has specified variables, so lets "render"
+        if len(variables) > 0:
+            for name, value in variables.items():
+                variable_template = f'{{$ {name} $}}'
+                if variable_template not in feature_content:
+                    errors_unused.add(name)
+                    continue
+
+                feature_content = feature_content.replace(variable_template, value)
+
+        # look for sub-variables that has not been rendered
+        if '{$' in feature_content and '$}' in feature_content:
+            matches = re.finditer(r'\{\$ ([^$]+) \$\}', feature_content, re.MULTILINE)
+
+            for match in matches:
+                errors_undeclared.add(match.group(1))
+
+        if len(errors_undeclared) + len(errors_unused) > 0:
+            scenario_identifier = f'{feature}#{scenario}'
+            buffer_error: List[str] = []
+            if len(errors_unused) > 0:
+                errors_unused_message = "\n  ".join(errors_unused)
+                buffer_error.append(f'the following variables has been declared in scenario tag but not used in {scenario_identifier}:\n  {errors_unused_message}')
+                buffer_error.append('')
+
+            if len(errors_undeclared) > 0:
+                errors_undeclared_message = "\n  ".join(errors_undeclared)
+                buffer_error.append(f'the following variables was used in {scenario_identifier} but was not declared in scenario tag:\n  {errors_undeclared_message}')
+                buffer_error.append('')
+
+            message = '\n'.join(buffer_error)
+            raise ValueError(message)
+
+        # check if we have nested `{% scenario .. %}` tags, and render
+        if '{% scenario' in feature_content:
+            template = self.environment.from_string(feature_content)
+            feature_content = template.render()
+        # // -->
+
         feature_lines = feature_content.splitlines()
         parsed_feature = parse_feature(feature_content, filename=feature_file.as_posix())
 
         buffer_feature: List[str] = []
-        errors_unused: Set[str] = set()
-        errors_undeclared: Set[str] = set()
 
         for parsed_scenario in cast(List[Scenario], parsed_feature.scenarios):
             if parsed_scenario.name != scenario:
@@ -90,41 +131,7 @@ class OnlyScenarioTag(StandaloneTag):
                         buffer_scenario.append(f'{" " * extra_indent}| {row_line} |')
 
             feature_scenario = '\n'.join(buffer_scenario)
-            # <!-- sub-render included scenario
-
-            # tag has specified variables, so lets "render"
-            if len(variables) > 0:
-                for name, value in variables.items():
-                    variable_template = f'{{$ {name} $}}'
-                    if variable_template not in feature_scenario:
-                        errors_unused.add(name)
-                        continue
-
-                    feature_scenario = feature_scenario.replace(variable_template, value)
-
-            # look for sub-variables that has not been rendered
-            if '{$' in feature_scenario and '$}' in feature_scenario:
-                matches = re.finditer(r'\{\$ ([^$]+) \$\}', feature_scenario, re.MULTILINE)
-
-                for match in matches:
-                    errors_undeclared.add(match.group(1))
-            # // -->
-
             buffer_feature.append(feature_scenario)
-
-        if len(errors_undeclared) + len(errors_unused) > 0:
-            scenario_identifier = f'{feature}#{scenario}'
-            buffer_error: List[str] = []
-            if len(errors_unused) > 0:
-                buffer_error.append(f'the following variables has been declared in scenario tag but not used in {scenario_identifier}:\n  {"\n  ".join(errors_unused)}')
-                buffer_error.append('')
-
-            if len(errors_undeclared) > 0:
-                buffer_error.append(f'the following variables was used in {scenario_identifier} but was not declared in scenario tag:\n  {"\n  ".join(errors_undeclared)}')
-                buffer_error.append('')
-
-            message = '\n'.join(buffer_error)
-            raise ValueError(message)
 
         return '\n'.join(buffer_feature)
 

--- a/grizzly_cli/run.py
+++ b/grizzly_cli/run.py
@@ -1,12 +1,14 @@
+from __future__ import annotations
+
 import sys
 import os
+import re
 
-from typing import Iterable, List, Dict, Any, Callable, Optional, TextIO, Union, cast
+from typing import Iterable, List, Dict, Any, Callable, Optional, TextIO, Union, Set, cast
 from argparse import Namespace as Arguments
 from platform import node as get_hostname
 from datetime import datetime
 from pathlib import Path
-from contextlib import suppress
 
 from jinja2 import Environment
 from jinja2.lexer import Token, TokenStream
@@ -37,7 +39,7 @@ class OnlyScenarioTag(StandaloneTag):
         self._source = source
         return cast(str, super().preprocess(source, name, filename))
 
-    def render(self, scenario: str, feature: str) -> str:
+    def render(self, scenario: str, feature: str, **variables: str) -> str:
         feature_file = Path(feature)
 
         # check if relative to parent feature file
@@ -48,11 +50,15 @@ class OnlyScenarioTag(StandaloneTag):
         feature_lines = feature_content.splitlines()
         parsed_feature = parse_feature(feature_content, filename=feature_file.as_posix())
 
-        buffer: List[str] = []
+        buffer_feature: List[str] = []
+        errors_unused: Set[str] = set()
+        errors_undeclared: Set[str] = set()
 
         for parsed_scenario in cast(List[Scenario], parsed_feature.scenarios):
             if parsed_scenario.name != scenario:
                 continue
+
+            buffer_scenario: List[str] = []
 
             scenario_line = feature_lines[parsed_scenario.line - 1]
             step_indent = (len(scenario_line) - len(scenario_line.lstrip())) * 2
@@ -64,26 +70,63 @@ class OnlyScenarioTag(StandaloneTag):
                 if index > 0:
                     step_line = f'{" " * step_indent}{step_line}'
 
-                buffer.append(step_line)
+                buffer_scenario.append(step_line)
 
                 extra_indent = int((step_indent / 2) + step_indent)
 
                 # include step text if set
                 if parsed_step.text is not None:
-                    buffer.append(f'{" " * extra_indent}"""')
+                    buffer_scenario.append(f'{" " * extra_indent}"""')
                     for text_line in parsed_step.text.splitlines():
-                        buffer.append(f'{" " * (extra_indent)}{text_line}')
-                    buffer.append(f'{" " * extra_indent}"""')
+                        buffer_scenario.append(f'{" " * (extra_indent)}{text_line}')
+                    buffer_scenario.append(f'{" " * extra_indent}"""')
 
                 # include step table if set
                 if parsed_step.table is not None:
                     header_line = ' | '.join(parsed_step.table.headings)
-                    buffer.append(f'{" " * extra_indent}| {header_line} |')
+                    buffer_scenario.append(f'{" " * extra_indent}| {header_line} |')
                     for row in cast(List[Row], parsed_step.table.rows):
                         row_line = ' | '.join(row.cells)
-                        buffer.append(f'{" " * extra_indent}| {row_line} |')
+                        buffer_scenario.append(f'{" " * extra_indent}| {row_line} |')
 
-        return '\n'.join(buffer)
+            feature_scenario = '\n'.join(buffer_scenario)
+            # <!-- sub-render included scenario
+
+            # tag has specified variables, so lets "render"
+            if len(variables) > 0:
+                for name, value in variables.items():
+                    variable_template = f'{{$ {name} $}}'
+                    if variable_template not in feature_scenario:
+                        errors_unused.add(name)
+                        continue
+
+                    feature_scenario = feature_scenario.replace(variable_template, value)
+
+            # look for sub-variables that has not been rendered
+            if '{$' in feature_scenario and '$}' in feature_scenario:
+                matches = re.finditer(r'\{\$ ([^$]+) \$\}', feature_scenario, re.MULTILINE)
+
+                for match in matches:
+                    errors_undeclared.add(match.group(1))
+            # // -->
+
+            buffer_feature.append(feature_scenario)
+
+        if len(errors_undeclared) + len(errors_unused) > 0:
+            scenario_identifier = f'{feature}#{scenario}'
+            buffer_error: List[str] = []
+            if len(errors_unused) > 0:
+                buffer_error.append(f'the following variables has been declared in scenario tag but not used in {scenario_identifier}:\n  {"\n  ".join(errors_unused)}')
+                buffer_error.append('')
+
+            if len(errors_undeclared) > 0:
+                buffer_error.append(f'the following variables was used in {scenario_identifier} but was not declared in scenario tag:\n  {"\n  ".join(errors_undeclared)}')
+                buffer_error.append('')
+
+            message = '\n'.join(buffer_error)
+            raise ValueError(message)
+
+        return '\n'.join(buffer_feature)
 
     def filter_stream(self, stream: TokenStream) -> Union[TokenStream, Iterable[Token]]:  # type: ignore[return]
         """Everything outside of `{% scenario ... %}` should be treated as "data", e.g. plain text.
@@ -355,5 +398,4 @@ def run(args: Arguments, run_func: Callable[[Arguments, Dict[str, Any], Dict[str
 
         return run_func(args, environ, run_arguments)
     finally:
-        with suppress(FileNotFoundError):
-            feature_lock_file.unlink()
+        feature_lock_file.unlink(missing_ok=True)

--- a/grizzly_cli/utils.py
+++ b/grizzly_cli/utils.py
@@ -166,15 +166,19 @@ def onerror(func: Callable, path: str, exc_info: Union[
         raise  # pylint: disable=E0704
 
 
-def rm_rf(path: Union[str, Path]) -> None:
+def rm_rf(path: Union[str, Path], *, missing_ok: bool = False) -> None:
     """Remove the path contents recursively, even if some elements
     are read-only."""
     p = path.as_posix() if isinstance(path, Path) else path
 
-    if sys.version_info >= (3, 12):
-        rmtree(p, onexc=onerror)
-    else:
-        rmtree(p, onerror=onerror)
+    try:
+        if sys.version_info >= (3, 12):
+            rmtree(p, onexc=onerror)
+        else:
+            rmtree(p, onerror=onerror)
+    except FileNotFoundError:
+        if not missing_ok:
+            raise
 
 
 def get_dependency_versions() -> Tuple[Tuple[Optional[str], Optional[List[str]]], Optional[str]]:

--- a/tests/e2e/test_run.py
+++ b/tests/e2e/test_run.py
@@ -4,7 +4,6 @@ from tempfile import NamedTemporaryFile
 from typing import Optional
 from os import path, pathsep
 from datetime import datetime
-from base64 import b64encode
 
 import pytest
 import yaml
@@ -182,16 +181,6 @@ def test_e2e_run_example(e2e_fixture: End2EndFixture) -> None:
             if sys.platform == 'darwin':
                 output = [line for line in log_file_result.split('\n') if 'ERROR' not in line and 'DEBUG' not in line]
                 log_file_result = '\n'.join(output)
-
-            print('result:')
-            print('-' * 100)
-            print(b64encode(result.encode()).decode())
-            print('-' * 100)
-            print('')
-            print('log_file_result:')
-            print('-' * 100)
-            print(b64encode(log_file_result.encode()).decode())
-            print('-' * 100)
 
             if sys.version_info >= (3, 12):
                 result = result.replace('\r', '\n')

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -2,8 +2,8 @@ from os import getcwd, path
 from argparse import ArgumentParser
 from datetime import datetime
 from pathlib import Path
-from contextlib import suppress
 
+import pytest
 from _pytest.capture import CaptureFixture
 from _pytest.tmpdir import TempPathFactory
 from pytest_mock import MockerFixture
@@ -372,7 +372,7 @@ bar = foo
         Given a variable with value "{{ some*0.25 | more}}" and another value "{{yes|box }}"
 
     Scenario: fourth
-        {% scenario "fourth", feature="./fourth.feature" %}
+        {% scenario "fourth", feature="./fourth.feature", foo="bar" %}
 """)
         feature_file_2 = execution_context / 'second.feature'
         feature_file_2.write_text("""Feature: a second feature
@@ -389,7 +389,8 @@ bar = foo
         Given a common step
 
     Scenario: fourth
-        Given a variable with value "{{ barfoo }}"
+        Given a variable with value "{{ {$ foo $}_barfoo }}"
+        Then get "{{ bar{$ foo $}foo }}" from "{{ {$ foo $}_barfoo }}"
         Then run a bloody test
 """)
 
@@ -431,7 +432,8 @@ bar = foo
         Given a variable with value "{{ some*0.25 | more}}" and another value "{{yes|box }}"
 
     Scenario: fourth
-        Given a variable with value "{{ barfoo }}"
+        Given a variable with value "{{ bar_barfoo }}"
+        Then get "{{ barbarfoo }}" from "{{ bar_barfoo }}"
         Then run a bloody test
 """
 
@@ -440,13 +442,13 @@ bar = foo
         Given a variable with value "{{ hello }}"
 
     Scenario: second
-        {% scenario "second", feature="../second.feature" %}
+        {% scenario "second", feature="../second.feature", prefix="s1" %}
 
     # Scenario: third
-    #     {% scenario "inactive-second", feature="./second.feature" %}
+    #     {% scenario "inactive-second", feature="./second.feature", prefix="s1" %}
 
     Scenario: third
-        {% scenario "third", feature="../second.feature" %}
+        {% scenario "third", feature="../second.feature", prefix="s1" %}
 """)
         feature_file_2 = execution_context / 'second.feature'
         feature_file_2.write_text("""Feature: a second feature
@@ -454,7 +456,7 @@ bar = foo
         Given a common step
 
     Scenario: second
-        Given a variable with value "{{ foobar }}"
+        Given a variable with value "{{ {$ prefix $}foobar }}"
         Then run a bloody test
             \"\"\"
             with step text
@@ -464,7 +466,7 @@ bar = foo
             \"\"\"
 
     Scenario: third
-        Given a variable with value "{{ value }}"
+        Given a variable with value "{{ {$ prefix $}value }}"
         Then run a bloody test, with table
           | hello | world |
           | foo   | bar   |
@@ -472,8 +474,7 @@ bar = foo
           |       | foo   |
 """)
 
-        with suppress(FileNotFoundError):
-            output_file.unlink()
+        output_file.unlink(missing_ok=True)
 
         arguments = parser.parse_args([
             'run',
@@ -499,7 +500,7 @@ bar = foo
         Given a variable with value "{{ hello }}"
 
     Scenario: second
-        Given a variable with value "{{ foobar }}"
+        Given a variable with value "{{ s1foobar }}"
         Then run a bloody test
             \"\"\"
             with step text
@@ -509,10 +510,10 @@ bar = foo
             \"\"\"
 
     # Scenario: third
-    #     {% scenario "inactive-second", feature="./second.feature" %}
+    #     {% scenario "inactive-second", feature="./second.feature", prefix="s1" %}
 
     Scenario: third
-        Given a variable with value "{{ value }}"
+        Given a variable with value "{{ s1value }}"
         Then run a bloody test, with table
             | hello | world |
             | foo | bar |
@@ -524,14 +525,65 @@ bar = foo
         Given a variable with value "{{ hello }}"
 
     Scenario: second
-        {% scenario "second", feature="../second.feature" %}
+        {% scenario "second", feature="../second.feature", prefix="s1" %}
 
     # Scenario: third
-    #     {% scenario "inactive-second", feature="./second.feature" %}
+    #     {% scenario "inactive-second", feature="./second.feature", prefix="s1" %}
 
     Scenario: third
-        {% scenario "third", feature="../second.feature" %}
+        {% scenario "third", feature="../second.feature", prefix="s1" %}
 """
+
+        feature_file.write_text("""Feature: a feature
+    Scenario: first
+        Given a variable with value "{{ hello }}"
+
+    Scenario: second
+        {% scenario "second", feature="../second.feature", foo="bar" %}
+""")
+        feature_file_2 = execution_context / 'second.feature'
+        feature_file_2.write_text("""Feature: a second feature
+    Background: common
+        Given a common step
+
+    Scenario: second
+        Given a variable with value "{{ {$ bar $}foobar }}"
+        Then run a bloody test
+            \"\"\"
+            with step text
+            that spans
+            more than
+            one line
+            \"\"\"
+""")
+
+        output_file.unlink(missing_ok=True)
+
+        arguments = parser.parse_args([
+            'run',
+            '-e', f'{execution_context}/configuration.yaml',
+            '--yes',
+            f'{execution_context}/features/test.feature',
+            '--dump', f'{execution_context}/output.feature'
+        ])
+        setattr(arguments, 'file', ' '.join(arguments.file))
+
+        with pytest.raises(ValueError) as ve:
+            run(arguments, local_mock)
+
+        assert str(ve.value) == '''the following variables has been declared in scenario tag but not used in ../second.feature#second:
+  foo
+
+the following variables was used in ../second.feature#second but was not declared in scenario tag:
+  bar
+'''
+
+        distributed_mock.assert_not_called()
+        local_mock.assert_not_called()
+
+        capture = capsys.readouterr()
+        assert capture.err == ''
+        assert capture.out == ''
     finally:
         tmp_path_factory._basetemp = original_tmp_path
         rm_rf(test_context)


### PR DESCRIPTION
makes it possible to use `{% scenario .. %}` tags in included scenarios (nested).

allows for special tag variables to be specified in included scenarios (`{$ foo $}`), which is specified in the tag, e.g.:

```gherkin
Scenario: second
  Given value for variable "{$ foo $}_var" is "none"
```

```gherkin
Scenario: main
  {% scenario "second", feature="./second.feature", foo="bar" %}
```

Results in:
```gherkin
Scenario: main
  Given value for variable "bar_var" is "none"
```