### PR TITLE
problems with mq redist 9.4.1.0 which is linked by the short-url.

### DIFF
--- a/grizzly_cli/static/Containerfile
+++ b/grizzly_cli/static/Containerfile
@@ -10,8 +10,10 @@ RUN apt-get update
 # <!-- mq
 FROM base AS mq
 
-ARG IBM_MQ_LIB_HOST=https://ibm.biz
-ARG IBM_MQ_LIB=IBM-MQC-Redist-LinuxX64targz
+#ARG IBM_MQ_LIB_HOST=https://ibm.biz
+#ARG IBM_MQ_LIB=IBM-MQC-Redist-LinuxX64targz
+ARG IBM_MQ_LIB_HOST=https://public.dhe.ibm.com
+ARG IBM_MQ_LIB=ibmdl/export/pub/software/websphere/messaging/mqdev/redist/9.4.0.6-IBM-MQC-Redist-LinuxX64.tar.gz
 
 RUN apt-get install -y --no-install-recommends wget
 


### PR DESCRIPTION
use 9.4.0.6 which has been confirmed to work.