### PR TITLE
temporary file permissions

### DIFF
--- a/grizzly_cli/utils/configuration.py
+++ b/grizzly_cli/utils/configuration.py
@@ -329,6 +329,10 @@ def _write_file(root: Path, content_type: str, encoded_content: str) -> str:
 
     file = root / 'files' / file_name
     file.parent.mkdir(parents=True, exist_ok=True)
+    file.parent.chmod(0o700)
+    file.touch()
+    file.chmod(0o600)
+
     complete = True
 
     if 'chunk' in content_type:  # 0 = chunk:N, 1 = chunks:T
@@ -424,6 +428,8 @@ def load_configuration(configuration_file: str) -> str:
         logger.info('loaded %d secrets from keyvault %s', number_of_keyvault_secrets, load_from_keyvault)
 
     environment_lock_file = file.parent / f'{file.stem}.lock{file.suffix}'
+    environment_lock_file.touch()
+    environment_lock_file.chmod(0o600)
 
     with environment_lock_file.open('w') as fd:
         yaml.dump(configuration, fd, Dumper=IndentDumper.use_indentation(file), default_flow_style=False, sort_keys=False, allow_unicode=True)

--- a/tests/unit/utils/test_configuration.py
+++ b/tests/unit/utils/test_configuration.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import MagicMock
 from base64 import b64encode
+from platform import system
 
 import pytest
 from _pytest.tmpdir import TempPathFactory
@@ -138,8 +139,10 @@ def test__write_file(tmp_path_factory: TempPathFactory) -> None:
         assert _write_file(test_context, 'file:foo/bar.txt', b64encode(b'foo bar').decode('utf-8')) == 'files/foo/bar.txt'
         f = test_context / 'files' / 'foo' / 'bar.txt'
         assert f.read_text() == 'foo bar'
-        assert f.parent.stat().st_mode & 0x000FFF == 0o700
-        assert f.stat().st_mode & 0x000FFF == 0o600
+
+        if system() != 'Windows':
+            assert f.parent.stat().st_mode & 0x000FFF == 0o700
+            assert f.stat().st_mode & 0x000FFF == 0o600
 
         f = test_context / 'files' / 'foobar.txt'
         f.touch()
@@ -161,8 +164,9 @@ def test__write_file(tmp_path_factory: TempPathFactory) -> None:
 
             assert f.read_text() == expected
 
-        assert f.parent.stat().st_mode & 0x000FFF == 0o700
-        assert f.stat().st_mode & 0x000FFF == 0o600
+        if system() != 'Windows':
+            assert f.parent.stat().st_mode & 0x000FFF == 0o700
+            assert f.stat().st_mode & 0x000FFF == 0o600
 
         with pytest.raises(ValueError, match='could not find `file:` in content type'):
             _write_file(test_context, 'noconf,chunk:0,chunks:2', 'foobar')
@@ -246,7 +250,9 @@ def test_load_configuration(mocker: MockerFixture, tmp_path_factory: TempPathFac
 
         env_file_lock = Path(env_file_lock_name)
 
-        assert env_file_lock.stat().st_mode & 0x000FFF == 0o600
+        if system() != 'Windows':
+            assert env_file_lock.stat().st_mode & 0x000FFF == 0o600
+
         assert env_file_lock.read_text() == env_file_local.read_text()
         load_configuration_keyvault_mock.assert_not_called()
 


### PR DESCRIPTION
files created related to keyvault secrets should not be readable by anyone other then the user running `grizzly-cli`, which inturn means, for distributed runs, the user that the docker containers execute with.