### PR TITLE
get_context_root should look for the "closest" environment.py

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -44,7 +44,10 @@
           "tests/"
         ],
         "coverage-gutters.xmlname": "coverage.xml",
-        "coverage-gutters.ignoredPathGlobs": "**/tests/**"
+        "coverage-gutters.ignoredPathGlobs": "**/tests/**",
+        "github.copilot.enable": {
+          "*": false
+        }
       },
       // Add the IDs of extensions you want installed when the container is created.
       "extensions": [

--- a/grizzly_cli/utils/configuration.py
+++ b/grizzly_cli/utils/configuration.py
@@ -20,11 +20,22 @@ from grizzly_cli.utils import IndentDumper, merge_dicts, logger, unflatten
 
 
 def get_context_root() -> Path:
-    possible_context_root = Path.cwd().rglob('environment.py')
-    try:
-        return next(possible_context_root).parent
-    except StopIteration:
+    possible_context_roots = Path.cwd().rglob('environment.py')
+
+    context_root: Path | None = None
+
+    for possible_context_root in possible_context_roots:
+        if context_root is None:
+            context_root = possible_context_root
+            continue
+
+        if possible_context_root.as_posix().count('/') < context_root.as_posix().count('/'):
+            context_root = possible_context_root
+
+    if context_root is None:
         raise ValueError('context root not found, are you in a grizzly project?')
+
+    return context_root.parent
 
 
 class ScenarioTag(StandaloneTag):


### PR DESCRIPTION
based on number of path seperators in the glob matches.

disable copilot in devcontainer, it just messes up the workflow with bad guesses/suggestions.